### PR TITLE
Improve CI/CD secrets documentation and fix web CI

### DIFF
--- a/.github/workflows/web-claude-code-review.yml
+++ b/.github/workflows/web-claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
             2. Potential bugs or issues
             3. Performance considerations (only flag obvious issues, not speculative optimizations)
             4. Security concerns
-            5. Test coverage: We aim for 60-80% coverage, not 100%. In real development with limited team size (might be solo dev), we focus on minimum testable solution. Prefer a few tests covering normal flow plus a few edge cases. When issues arise, we add unit tests to prevent regression. We can focus on comprehensive testing later if needed.
+            5. Test coverage: We aim for 40-60% coverage, not 100%. In real development with limited team size (might be solo dev), we focus on minimum testable solution. Prefer a few tests covering normal flow plus a few edge cases. When issues arise, we add unit tests to prevent regression. We can focus on comprehensive testing later if needed.
 
             Format your feedback:
               - Group issues by priority:

--- a/.github/workflows/web-ubuntu.yml
+++ b/.github/workflows/web-ubuntu.yml
@@ -30,6 +30,7 @@ jobs:
 
     steps:
       - name: Install dependencies for Codecov
+        working-directory: /
         run: apt-get update && apt-get install -y git curl gpg
 
       - name: Checkout code

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -41,5 +41,14 @@ COMPANY_SOCIAL_LINKS={ "twitter": "https://twitter.com/example" }
 CAPTCHA_SECRET_KEY=your-recaptcha-secret-key
 SENTRY_DSN=https://your-sentry-dsn
 
-# CI/CD (only set in GitHub secrets, not in .env files)
-# CODECOV_TOKEN=your-codecov-upload-token
+# =============================================================================
+# CI/CD secrets only (not needed for local development)
+# =============================================================================
+
+# Codecov token for code coverage reports
+# Get from: https://app.codecov.io/gh/<github-profile>/<repository>/config/general
+# CODECOV_TOKEN=
+
+# AI-assistant to review pull requests and suggest improvements
+# Can be generated via `claude setup-token` (requires Pro subscription or above)
+# CLAUDE_CODE_OAUTH_TOKEN=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -29,14 +29,17 @@ VITE_E2E_ADMIN_EMAIL=
 VITE_E2E_ADMIN_PASSWORD=
 
 # =============================================================================
-# CI/CD SECRETS (GitHub Actions test environment only)
+# CI/CD secrets only (not needed for local development)
 # =============================================================================
-# ⚠️ NOT needed for local development, staging, or production
 
 # RelativeCI API key for bundle analysis
 # Get from: https://app.relative-ci.com/projects/zeITj9gEk1AMeNTP87R8/settings/keys
 # RELATIVE_CI_KEY=
 
 # Codecov token for code coverage reports
-# Get from: https://app.codecov.io/gh/SlavaMelanko/smela-front/config/general
+# Get from: https://app.codecov.io/gh/<github-profile>/<repository>/config/general
 # CODECOV_TOKEN=
+
+# AI-assistant to review pull requests and suggest improvements
+# Can be generated via `claude setup-token` (requires Pro subscription or above)
+# CLAUDE_CODE_OAUTH_TOKEN=


### PR DESCRIPTION
[Improvement]: Standardize CI/CD secrets section across api and web env examples with consistent formatting
[Improvement]: Add source URLs for Codecov and Claude OAuth tokens so developers know where to find them
[Improvement]: Use generic placeholders for GitHub profile and repository in Codecov URL instead of hardcoded values
[Fix]: Lower web code review workflow test coverage target from 60-80% to 40-60% for solo/small team expectations
[Fix]: Add working-directory: / to web CI apt-get step to avoid missing directory error before checkout