### PR TITLE
Add SonarQube config for monorepo

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,32 +2,27 @@
 sonar.projectKey=smela
 sonar.projectName=smela
 
-# Monorepo modules
-sonar.modules=api,web
+# Sources and tests
+sonar.sources=apps/api/src,apps/web/src
+sonar.tests=apps/api/src,apps/web/src
 
-api.sonar.projectName=@smela/api
-api.sonar.projectBaseDir=apps/api
-api.sonar.sources=src
-api.sonar.tests=src
-api.sonar.test.inclusions=**/*.test.ts
-api.sonar.coverage.exclusions=src/**/*.test.ts
-api.sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.test.inclusions=\
+  apps/api/**/*.test.ts,\
+  apps/web/**/__tests__/**,\
+  apps/web/**/*.test.js,\
+  apps/web/**/*.spec.js
 
-web.sonar.projectName=@smela/web
-web.sonar.projectBaseDir=apps/web
-web.sonar.sources=src
-web.sonar.tests=src
-web.sonar.test.inclusions=**/__tests__/**,**/*.spec.js,**/*.test.js
-web.sonar.coverage.exclusions=src/**/*.stories.*,src/**/*.test.*,src/**/*.spec.*,src/tests/**
-web.sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=\
+  apps/api/coverage/lcov.info,\
+  apps/web/coverage/lcov.info
 
 # Exclusions
 sonar.exclusions=\
-  apps/api/src/data/migrations/**/*.sql,\
   **/node_modules/**,\
   **/dist/**,\
   **/coverage/**,\
-  **/*.stories.*
+  **/*.stories.*,\
+  apps/api/src/data/migrations/**/*.sql
 
 sonar.coverage.exclusions=\
   apps/api/src/data/scripts/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,35 @@
+# Identity
+sonar.projectKey=smela
+sonar.projectName=smela
+
+# Monorepo modules
+sonar.modules=api,web
+
+api.sonar.projectName=@smela/api
+api.sonar.projectBaseDir=apps/api
+api.sonar.sources=src
+api.sonar.tests=src
+api.sonar.test.inclusions=**/*.test.ts
+api.sonar.coverage.exclusions=src/**/*.test.ts
+api.sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+web.sonar.projectName=@smela/web
+web.sonar.projectBaseDir=apps/web
+web.sonar.sources=src
+web.sonar.tests=src
+web.sonar.test.inclusions=**/__tests__/**,**/*.spec.js,**/*.test.js
+web.sonar.coverage.exclusions=src/**/*.stories.*,src/**/*.test.*,src/**/*.spec.*,src/tests/**
+web.sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclusions
+sonar.exclusions=\
+  apps/api/src/data/migrations/**/*.sql,\
+  **/node_modules/**,\
+  **/dist/**,\
+  **/coverage/**,\
+  **/*.stories.*
+
+sonar.coverage.exclusions=\
+  apps/api/src/data/scripts/**,\
+  apps/api/src/emails/**,\
+  apps/web/src/tests/**


### PR DESCRIPTION
[Feature]: Add \`sonar-project.properties\` with combined sources from \`apps/api\` and \`apps/web\`
[Feature]: Wire LCOV coverage reports from Bun (\`apps/api\`) and Jest (\`apps/web\`) to SonarCloud
[Improvement]: Exclude generated Drizzle migration SQL files from analysis
[Improvement]: Exclude node_modules, dist, coverage, and Storybook story files globally
[Improvement]: Exclude non-production paths (scripts, email templates, test setup) from coverage tracking

> **Note:** Uses single-project layout (no \`sonar.modules\`) — compatible with SonarCloud free tier. Path-based filtering in the UI provides the \`api\` vs \`web\` split.