### PR TITLE
Fix ESLint lint warnings across api and web

### DIFF
--- a/apps/api/src/__tests__/request.ts
+++ b/apps/api/src/__tests__/request.ts
@@ -1,5 +1,7 @@
 import type { Hono } from 'hono'
 
+const DEFAULT_HEADERS = { 'Content-Type': 'application/json' }
+
 export const doRequest = async (
   app: Hono,
   url: string,
@@ -17,7 +19,7 @@ export const post = async (
   app: Hono,
   url: string,
   body?: any,
-  headers: Record<string, string> = { 'Content-Type': 'application/json' },
+  headers: Record<string, string> = DEFAULT_HEADERS,
 ) =>
   doRequest(app, url, 'POST', body, headers)
 
@@ -32,6 +34,6 @@ export const patch = async (
   app: Hono,
   url: string,
   body?: any,
-  headers: Record<string, string> = { 'Content-Type': 'application/json' },
+  headers: Record<string, string> = DEFAULT_HEADERS,
 ) =>
   doRequest(app, url, 'PATCH', body, headers)

--- a/apps/web/src/components/Sidebar/Sidebar.jsx
+++ b/apps/web/src/components/Sidebar/Sidebar.jsx
@@ -31,7 +31,7 @@ import { ActiveIndicator } from './ActiveIndicator'
 const formatBadge = count => {
   const num = Number(count)
 
-  return isNaN(num) || num <= 0 ? '0' : num > 9 ? '9+' : num
+  return Number.isNaN(num) || num <= 0 ? '0' : num > 9 ? '9+' : num
 }
 
 export const Sidebar = ({ items, team }) => {

--- a/apps/web/src/components/pricing/PricingSlider/PlanSummary.jsx
+++ b/apps/web/src/components/pricing/PricingSlider/PlanSummary.jsx
@@ -5,14 +5,14 @@ import { Bandwidth, PricePerUnit, TotalPrice } from '../Pricing'
 const getPricePerGB = bandwidth => {
   const price = 4 - ((bandwidth - 1) / 998) * 2
 
-  return parseFloat(price.toFixed(2))
+  return Number.parseFloat(price.toFixed(2))
 }
 
 const getPricePerGbWithDiscount = (bandwidth, discount) => {
   const price = 4 - ((bandwidth - 1) / 998) * 2
   const priceWithDiscount = price * (1 - discount / 100)
 
-  return parseFloat(priceWithDiscount.toFixed(2))
+  return Number.parseFloat(priceWithDiscount.toFixed(2))
 }
 
 const SummaryItem = ({ label, value }) => (

--- a/apps/web/src/hooks/useUrlParams.js
+++ b/apps/web/src/hooks/useUrlParams.js
@@ -22,7 +22,7 @@ export const useUrlParams = (keys = [], options = {}) => {
     keys.map(key => {
       let value = params.get(key) || undefined
 
-      if (value && parseNumbers && !isNaN(value)) {
+      if (value && parseNumbers && !Number.isNaN(value)) {
         value = stringToNumber(value)
       } else if (value && parseBooleans) {
         value = stringToBoolean(value)


### PR DESCRIPTION
[Fix]: Replace object literal default parameter with a named constant to satisfy ESLint rule in api test helpers
[Fix]: Replace global `isNaN` with `Number.isNaN` in Sidebar and useUrlParams hook
[Fix]: Replace global `parseFloat` with `Number.parseFloat` in PricingSlider PlanSummary