### PR TITLE
Extract ColumnResizeHandle with a11y and SRP fix

### DIFF
--- a/apps/web/src/components/table/ColumnResizeHandle.jsx
+++ b/apps/web/src/components/table/ColumnResizeHandle.jsx
@@ -1,0 +1,33 @@
+import { cn } from '@/lib/utils'
+
+export const ColumnResizeHandle = ({ header }) => (
+  <div
+    role='separator'
+    tabIndex={0}
+    aria-label='Resize column'
+    aria-orientation='vertical'
+    onDoubleClick={e => {
+      e.stopPropagation()
+      header.column.resetSize()
+    }}
+    onMouseDown={e => {
+      e.stopPropagation()
+      header.getResizeHandler()(e)
+    }}
+    onTouchStart={e => {
+      e.stopPropagation()
+      header.getResizeHandler()(e)
+    }}
+    onKeyDown={e => {
+      e.stopPropagation()
+
+      if (e.key === 'Enter' || e.key === ' ') {
+        header.column.resetSize()
+      }
+    }}
+    className={cn(
+      'absolute right-0 top-0 h-full w-1 cursor-col-resize touch-none select-none rounded-full opacity-0 transition-opacity hover:bg-border hover:opacity-100',
+      header.column.getIsResizing() && 'bg-primary opacity-100'
+    )}
+  />
+)

--- a/apps/web/src/components/table/TableHeader.jsx
+++ b/apps/web/src/components/table/TableHeader.jsx
@@ -6,7 +6,8 @@ import {
   TableHeader as TableHeaderRoot,
   TableRow
 } from '@/components/ui'
-import { cn } from '@/lib/utils'
+
+import { ColumnResizeHandle } from './ColumnResizeHandle'
 
 export const TableHeader = ({ config }) => (
   <TableHeaderRoot>
@@ -32,15 +33,7 @@ export const TableHeader = ({ config }) => (
                 {isSorted === 'asc' && <ChevronUp className='size-4' />}
                 {isSorted === 'desc' && <ChevronDown className='size-4' />}
               </span>
-              <div
-                onDoubleClick={() => header.column.resetSize()}
-                onMouseDown={header.getResizeHandler()}
-                onTouchStart={header.getResizeHandler()}
-                className={cn(
-                  'absolute right-0 top-0 h-full w-1 cursor-col-resize touch-none select-none rounded-full opacity-0 transition-opacity hover:bg-border hover:opacity-100',
-                  header.column.getIsResizing() && 'bg-primary opacity-100'
-                )}
-              />
+              <ColumnResizeHandle header={header} />
             </TableHead>
           )
         })}


### PR DESCRIPTION
[Fix]: Add ARIA role, tabIndex, aria-label, and keyboard support to the column resize handle to satisfy accessibility requirements for non-native interactive elements
[Improvement]: Extract resize handle logic into a dedicated ColumnResizeHandle component, improving single responsibility in TableHeader
[Fix]: Stop event propagation on all resize handle interactions to prevent accidental column sort when resizing