### PR TITLE
Add tmux split-pane dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint:fix": "bun run --filter @smela/api lint:fix & bun run --filter @smela/web lint:fix & wait $(jobs -p)",
     "dev:web": "bun run --filter @smela/web dev",
     "dev:api": "bun run --filter @smela/api dev",
-    "dev": "bash scripts/dev.sh",
+    "dev": "bun run dev:api & bun run dev:web",
+    "dev:tmux": "bash scripts/dev.sh",
     "check:web": "bun run --filter @smela/web check",
     "check:api": "bun run --filter @smela/api check",
     "check": "bun run check:api & bun run check:web & wait $(jobs -p)"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "bun run --filter @smela/api lint:fix & bun run --filter @smela/web lint:fix & wait $(jobs -p)",
     "dev:web": "bun run --filter @smela/web dev",
     "dev:api": "bun run --filter @smela/api dev",
-    "dev": "bun run dev:api & bun run dev:web",
+    "dev": "bash scripts/dev.sh",
     "check:web": "bun run --filter @smela/web check",
     "check:api": "bun run --filter @smela/api check",
     "check": "bun run check:api & bun run check:web & wait $(jobs -p)"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+SESSION="smela-dev"
+
+tmux new-session -d -s $SESSION -x "$(tput cols)" -y "$(tput lines)"
+
+tmux split-window -h -t $SESSION
+
+tmux send-keys -t $SESSION:0.0 "cd apps/api && bun run dev" Enter
+tmux send-keys -t $SESSION:0.1 "cd apps/web && bun run dev" Enter
+
+tmux attach-session -t $SESSION


### PR DESCRIPTION
[Feature]: Add \`scripts/dev.sh\` to launch a tmux session with API and Web logs in side-by-side panes
[Improvement]: Add \`dev:tmux\` script as an opt-in alternative to the default \`dev\` command, keeping CI and tooling unaffected