### PR TITLE
Harden Docker and SonarQube security config

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -10,7 +10,8 @@ node_modules
 
 # Documentation
 *.md
-!CLAUDE.md
+CLAUDE.md
+postman.json
 
 # OS
 .DS_Store
@@ -26,6 +27,16 @@ node_modules
 dist
 .cache
 
+# Tests
+**/*.test.ts
+**/*.spec.ts
+
 # Test coverage
 coverage
 .nyc_output
+
+# CI/CD
+.github
+
+# Scripts
+*.sh

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /app
 COPY --from=build-staging /app/dist ./dist
 COPY --from=build-staging /app/node_modules ./node_modules
 ENV NODE_ENV=staging
+USER bun
 CMD ["bun", "dist/app.js"]
 
 # Build production bundle (minified, no source maps)
@@ -45,4 +46,5 @@ WORKDIR /app
 COPY --from=build-production /app/dist ./dist
 COPY --from=build-production /app/node_modules ./node_modules
 ENV NODE_ENV=production
+USER bun
 CMD ["bun", "dist/app.js"]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,7 +22,11 @@ sonar.exclusions=\
   **/dist/**,\
   **/coverage/**,\
   **/*.stories.*,\
-  apps/api/src/data/migrations/**/*.sql
+  apps/api/src/data/migrations/**/*.sql,\
+  apps/api/**/*.test.ts,\
+  apps/web/**/__tests__/**,\
+  apps/web/**/*.test.js,\
+  apps/web/**/*.spec.js
 
 sonar.coverage.exclusions=\
   apps/api/src/data/scripts/**,\


### PR DESCRIPTION
[Security]: Drop root privileges in staging and production Docker images using the built-in \`bun\` user
[Security]: Exclude sensitive files (CLAUDE.md, postman.json, test files, CI configs, scripts) from Docker build context
[Fix]: Add test file patterns to \`sonar.exclusions\` to suppress false-positive security hotspots from test code