### PR TITLE
Fix Docker build to use monorepo root as context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Exclude web app sources but keep package.json for workspace resolution
+apps/web
+!apps/web/package.json
+
+# Dependencies (reinstalled inside Docker)
+node_modules
+apps/api/node_modules
+
+# Git
+.git
+
+# Environment files (except test)
+apps/api/.env*
+!apps/api/.env.test
+
+# Documentation
+*.md
+CLAUDE.md
+apps/api/CLAUDE.md
+apps/api/postman.json
+
+# OS
+.DS_Store
+
+# Editors
+.vscode
+.idea
+apps/api/.vscode
+
+# Logs
+*.log
+
+# Build output
+apps/api/dist
+apps/api/.cache
+
+# Test coverage
+apps/api/coverage
+apps/api/.nyc_output
+
+# CI/CD
+.github
+
+# Scripts
+*.sh

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,14 +1,19 @@
 # Use the official Bun image
 # https://bun.com/guides/ecosystem/docker
-FROM oven/bun:1.2.16 AS base
+#
+# Build context must be the monorepo root, e.g.:
+#   docker build -f apps/api/Dockerfile --target test .
+FROM oven/bun:1.3.0 AS base
 
 WORKDIR /app
 
 # Install dependencies into temp directory
 # This will cache them and speed up future builds
 FROM base AS install
-RUN mkdir -p /temp/test
+RUN mkdir -p /temp/test/apps/api /temp/test/apps/web
 COPY package.json bun.lock /temp/test/
+COPY apps/api/package.json /temp/test/apps/api/
+COPY apps/web/package.json /temp/test/apps/web/
 WORKDIR /temp/test
 RUN bun install --frozen-lockfile
 
@@ -16,17 +21,17 @@ RUN bun install --frozen-lockfile
 # Then copy all (non-ignored) project files into the image
 FROM base AS test
 COPY --from=install /temp/test/node_modules ./node_modules
-COPY . .
+COPY apps/api/ .
 CMD ["bun", "run", "test"]
 
 # Build staging bundle (with source maps for debugging)
 FROM base AS build-staging
 COPY --from=install /temp/test/node_modules ./node_modules
-COPY . .
+COPY apps/api/ .
 RUN bun run build:staging
 
 # Staging image — includes source maps
-FROM oven/bun:1.2.16-slim AS staging
+FROM oven/bun:1.3.0-slim AS staging
 WORKDIR /app
 COPY --from=build-staging /app/dist ./dist
 COPY --from=build-staging /app/node_modules ./node_modules
@@ -37,11 +42,11 @@ CMD ["bun", "dist/app.js"]
 # Build production bundle (minified, no source maps)
 FROM base AS build-production
 COPY --from=install /temp/test/node_modules ./node_modules
-COPY . .
+COPY apps/api/ .
 RUN bun run build
 
 # Production image — minimal, no source or devDeps
-FROM oven/bun:1.2.16-slim AS production
+FROM oven/bun:1.3.0-slim AS production
 WORKDIR /app
 COPY --from=build-production /app/dist ./dist
 COPY --from=build-production /app/node_modules ./node_modules

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,9 +23,9 @@
     "tsc": "bunx tsc --noEmit",
     "check": "bun run lint:fix && bun run tsc && bun run test",
     "emails": "email dev --dir src/emails --port 3001",
-    "docker:build": "docker build -t smela-back --target production .",
-    "docker:build:staging": "docker build -t smela-back-staging --target staging .",
-    "docker:test": "docker build -t smela-back-test --target test . && docker run --rm smela-back-test"
+    "docker:build": "docker build -f $(pwd)/Dockerfile -t smela-api --target production ../..",
+    "docker:build:staging": "docker build -f $(pwd)/Dockerfile -t smela-api-staging --target staging ../..",
+    "docker:test": "docker build -f $(pwd)/Dockerfile -t smela-api-test --target test ../.. && docker run --rm smela-api-test"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.7.6",


### PR DESCRIPTION
[Fix]: Docker build context changed to monorepo root so `bun.lock` (at repo root) is accessible during image build
[Fix]: Dockerfile COPY paths updated to `apps/api/` prefix to work with new root build context
[Fix]: Bun workspace resolution fixed by copying all workspace `package.json` files before `bun install`
[Improvement]: Bump Bun image version from 1.2.16 to 1.3.0 to match local runtime and avoid lockfile format mismatch
[Improvement]: Add root-level `.dockerignore` to exclude `apps/web` sources while keeping `apps/web/package.json` for workspace resolution
[Improvement]: Rename Docker image tags from `smela-back` to `smela-api` for clarity