### PR TITLE
Replace global with globalThis in test files

### DIFF
--- a/apps/web/src/components/form/__tests__/PermissionsMatrix.test.jsx
+++ b/apps/web/src/components/form/__tests__/PermissionsMatrix.test.jsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form'
 import { renderWithProviders } from '@/tests'
 
 // Mock PointerEvent for JSDOM
-global.PointerEvent = global.Event
+globalThis.PointerEvent = globalThis.Event
 
 import { PermissionsMatrix } from '../PermissionsMatrix'
 

--- a/apps/web/src/components/inputs/Multiselect/__tests__/Multiselect.test.jsx
+++ b/apps/web/src/components/inputs/Multiselect/__tests__/Multiselect.test.jsx
@@ -5,7 +5,7 @@ import { Multiselect } from '../Multiselect'
 
 // Mock browser APIs for tests
 beforeAll(() => {
-  global.ResizeObserver = class ResizeObserver {
+  globalThis.ResizeObserver = class ResizeObserver {
     observe() {}
     unobserve() {}
     disconnect() {}

--- a/apps/web/src/pages/errors/General/__tests__/General.test.jsx
+++ b/apps/web/src/pages/errors/General/__tests__/General.test.jsx
@@ -8,7 +8,7 @@ import { GeneralErrorPage } from '../index'
 
 describe('GeneralErrorPage', () => {
   beforeEach(() => {
-    global.mockNavigate.mockClear()
+    globalThis.mockNavigate.mockClear()
   })
 
   it('renders error icon, title, message, and button', () => {
@@ -34,7 +34,7 @@ describe('GeneralErrorPage', () => {
 
     await user.click(screen.getByRole('button', { name: en.error.general.cta }))
 
-    expect(global.mockNavigate).toHaveBeenCalledWith('/')
-    expect(global.mockNavigate).toHaveBeenCalledTimes(1)
+    expect(globalThis.mockNavigate).toHaveBeenCalledWith('/')
+    expect(globalThis.mockNavigate).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/pages/errors/Network/__tests__/Network.test.jsx
+++ b/apps/web/src/pages/errors/Network/__tests__/Network.test.jsx
@@ -12,7 +12,7 @@ jest.mock('@/hooks/useUrlParams')
 
 describe('NetworkErrorPage', () => {
   beforeEach(() => {
-    global.mockNavigate.mockClear()
+    globalThis.mockNavigate.mockClear()
     useUrlParams.mockClear()
     useUrlParams.mockReturnValue({ errorType: null })
   })
@@ -50,7 +50,7 @@ describe('NetworkErrorPage', () => {
 
     await user.click(screen.getByRole('button', { name: en.error.network.cta }))
 
-    expect(global.mockNavigate).toHaveBeenCalledWith(-1)
-    expect(global.mockNavigate).toHaveBeenCalledTimes(1)
+    expect(globalThis.mockNavigate).toHaveBeenCalledWith(-1)
+    expect(globalThis.mockNavigate).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/pages/errors/NotFound/__tests__/NotFound.test.jsx
+++ b/apps/web/src/pages/errors/NotFound/__tests__/NotFound.test.jsx
@@ -9,7 +9,7 @@ import { NotFoundErrorPage } from '../index'
 
 describe('NotFoundErrorPage', () => {
   beforeEach(() => {
-    global.mockNavigate.mockClear()
+    globalThis.mockNavigate.mockClear()
     captureMessage.mockClear()
   })
 
@@ -38,8 +38,8 @@ describe('NotFoundErrorPage', () => {
       screen.getByRole('button', { name: en.error.notFound.cta })
     )
 
-    expect(global.mockNavigate).toHaveBeenCalledWith('/')
-    expect(global.mockNavigate).toHaveBeenCalledTimes(1)
+    expect(globalThis.mockNavigate).toHaveBeenCalledWith('/')
+    expect(globalThis.mockNavigate).toHaveBeenCalledTimes(1)
   })
 
   it('reports 404 to error tracker on mount', () => {

--- a/apps/web/src/tests/jest.setup.js
+++ b/apps/web/src/tests/jest.setup.js
@@ -4,11 +4,11 @@ import { cleanup } from '@testing-library/react'
 import { TextDecoder, TextEncoder } from 'util'
 
 // Ensure text encoding/decoding works in JSDOM
-global.TextEncoder = TextEncoder
-global.TextDecoder = TextDecoder
+globalThis.TextEncoder = TextEncoder
+globalThis.TextDecoder = TextDecoder
 
 // Mock fetch globally
-global.fetch = jest.fn()
+globalThis.fetch = jest.fn()
 
 jest.mock('@/lib/env', () => ({
   default: {
@@ -22,8 +22,8 @@ jest.mock('@/lib/env', () => ({
 const mockExecuteReCaptcha = jest.fn()
 const mockResetReCaptcha = jest.fn()
 
-global.mockExecuteReCaptcha = mockExecuteReCaptcha
-global.mockResetReCaptcha = mockResetReCaptcha
+globalThis.mockExecuteReCaptcha = mockExecuteReCaptcha
+globalThis.mockResetReCaptcha = mockResetReCaptcha
 
 jest.mock('@/components/InvisibleReCaptcha', () => {
   const { useImperativeHandle } = jest.requireActual('react')
@@ -43,7 +43,7 @@ jest.mock('@/components/InvisibleReCaptcha', () => {
 
 const mockNavigate = jest.fn()
 
-global.mockNavigate = mockNavigate
+globalThis.mockNavigate = mockNavigate
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),


### PR DESCRIPTION
[Improvement]: Replace Node.js-specific \`global\` with standard ES2020 \`globalThis\` across all test setup and unit test files for cross-environment consistency