### PR TITLE
Fix SonarCloud project key and organization

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 # Identity
-sonar.projectKey=smela
+sonar.projectKey=SlavaMelanko_smela
 sonar.projectName=smela
+sonar.organization=smelanko
 
 # Sources and tests
 sonar.sources=apps/api/src,apps/web/src


### PR DESCRIPTION
[Fix]: Correct project key from \`smela\` to \`SlavaMelanko_smela\` to match SonarCloud project identity
[Fix]: Add missing \`sonar.organization=smelanko\` so analysis is routed to the correct organization