### PR TITLE
Pin Bun version to 1.3.0

### DIFF
--- a/.github/workflows/api-ci-ubuntu.yml
+++ b/.github/workflows/api-ci-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
   ci:
     name: Lint, Type Check & Tests
     runs-on: ubuntu-latest
-    container: oven/bun:latest
+    container: oven/bun:1.3.0
     environment: api-test
     defaults:
       run:

--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
   check-code-and-coverage:
     name: Format, Lint & Tests
     runs-on: ubuntu-latest
-    container: oven/bun:latest
+    container: oven/bun:1.3.0
     environment: web-test
     defaults:
       run:
@@ -68,7 +68,7 @@ jobs:
     name: Bundle Analysis (RelativeCI)
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
-    container: oven/bun:latest
+    container: oven/bun:1.3.0
     environment: web-test
     defaults:
       run:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official Bun image
 # https://bun.com/guides/ecosystem/docker
-FROM oven/bun:1.2.16 AS base
+FROM oven/bun:1.3.0 AS base
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ COPY . .
 RUN bun run build:staging
 
 # Staging image — includes source maps
-FROM oven/bun:1.2.16-slim AS staging
+FROM oven/bun:1.3.0-slim AS staging
 WORKDIR /app
 COPY --from=build-staging /app/dist ./dist
 COPY --from=build-staging /app/node_modules ./node_modules
@@ -41,7 +41,7 @@ COPY . .
 RUN bun run build
 
 # Production image — minimal, no source or devDeps
-FROM oven/bun:1.2.16-slim AS production
+FROM oven/bun:1.3.0-slim AS production
 WORKDIR /app
 COPY --from=build-production /app/dist ./dist
 COPY --from=build-production /app/node_modules ./node_modules


### PR DESCRIPTION
[Improvement]: Pin \`oven/bun\` to version 1.3.0 in CI workflows and Dockerfile to match the local dev machine version, preventing version drift between environments