### PR TITLE
Remove version field from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "smela",
   "private": true,
-  "version": "2026.03.20",
   "workspaces": [
     "apps/web",
     "apps/api"


### PR DESCRIPTION
[Improvement]: Remove meaningless version field from private monorepo root — versioning belongs to individual apps, not the workspace root