### PR TITLE
Persist table column visibility to localStorage

### DIFF
--- a/apps/web/src/components/team/TeamMembersSection/TeamMembersSection.jsx
+++ b/apps/web/src/components/team/TeamMembersSection/TeamMembersSection.jsx
@@ -1,5 +1,4 @@
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import { useState } from 'react'
 
 import { InviteButton } from '@/components/buttons'
 import { Spinner } from '@/components/Spinner'
@@ -11,11 +10,12 @@ import {
   createOpenItem
 } from '@/components/table/contextMenuItems'
 import { useCurrentUser } from '@/hooks/useAuth'
+import { useColumnVisibility } from '@/hooks/useColumnVisibility'
 import { useDeleteTeamMember } from '@/hooks/useDeleteTeamMember'
 import { useLocale } from '@/hooks/useLocale'
 import { useTeamMembers } from '@/hooks/useTeam'
 
-import { defaultHiddenColumns, getColumns } from './columns'
+import { getColumns } from './columns'
 import { useInvite } from './useTeamMembersInvite'
 
 const coreRowModel = getCoreRowModel()
@@ -65,7 +65,10 @@ export const TeamMembersSection = ({
   ]
 
   const columns = getColumns(t, formatDate, me?.id)
-  const [columnVisibility, setColumnVisibility] = useState(defaultHiddenColumns)
+  const [columnVisibility, setColumnVisibility] = useColumnVisibility(
+    'team-members',
+    columns
+  )
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const config = useReactTable({

--- a/apps/web/src/components/team/TeamMembersSection/columns.jsx
+++ b/apps/web/src/components/team/TeamMembersSection/columns.jsx
@@ -8,7 +8,8 @@ export const getColumns = (t, formatDate, meId) => {
   return [
     {
       accessorKey: 'id',
-      header: label('id')
+      header: label('id'),
+      hidden: true
     },
     {
       accessorKey: 'name',
@@ -38,7 +39,8 @@ export const getColumns = (t, formatDate, meId) => {
       accessorKey: 'invitedBy',
       header: label('invitedBy'),
       accessorFn: row => getFullName(row?.inviter),
-      cell: info => info.getValue() ?? ''
+      cell: info => info.getValue() ?? '',
+      hidden: true
     },
     {
       accessorKey: 'joinedAt',
@@ -48,13 +50,8 @@ export const getColumns = (t, formatDate, meId) => {
     {
       accessorKey: 'lastActive',
       header: label('lastActive'),
-      cell: info => <LastActiveBadge date={info.getValue()} />
+      cell: info => <LastActiveBadge date={info.getValue()} />,
+      hidden: true
     }
   ]
-}
-
-export const defaultHiddenColumns = {
-  id: false,
-  invitedBy: false,
-  lastActive: false
 }

--- a/apps/web/src/hooks/__tests__/useColumnVisibility.test.js
+++ b/apps/web/src/hooks/__tests__/useColumnVisibility.test.js
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useColumnVisibility } from '../useColumnVisibility'
+
+const columns = [
+  { accessorKey: 'id', hidden: true },
+  { accessorKey: 'name' },
+  { accessorKey: 'email' },
+  { accessorKey: 'updatedAt', hidden: true }
+]
+
+const defaults = { id: false, name: true, email: true, updatedAt: false }
+
+describe('useColumnVisibility', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('initializes with defaults derived from column definitions', () => {
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    expect(result.current[0]).toEqual(defaults)
+  })
+
+  it('updates visibility when setter is called', () => {
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    act(() => {
+      result.current[1]({ ...defaults, id: true })
+    })
+
+    expect(result.current[0].id).toBe(true)
+  })
+
+  it('persists only diff from defaults to localStorage', () => {
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    act(() => {
+      result.current[1]({ ...defaults, id: true })
+    })
+
+    const stored = JSON.parse(window.localStorage.getItem('table:columns:test'))
+
+    expect(stored).toEqual({ id: true })
+  })
+
+  it('removes localStorage key when visibility reverts to defaults', () => {
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    act(() => {
+      result.current[1]({ ...defaults, id: true })
+    })
+
+    act(() => {
+      result.current[1](defaults)
+    })
+
+    expect(window.localStorage.getItem('table:columns:test')).toBeNull()
+  })
+
+  it('restores visibility from localStorage on mount', () => {
+    window.localStorage.setItem(
+      'table:columns:test',
+      JSON.stringify({ id: true })
+    )
+
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    expect(result.current[0]).toEqual({ ...defaults, id: true })
+  })
+
+  it('supports updater function as argument', () => {
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    act(() => {
+      result.current[1](prev => ({ ...prev, id: true }))
+    })
+
+    expect(result.current[0].id).toBe(true)
+  })
+
+  it('falls back to defaults when localStorage contains invalid JSON', () => {
+    window.localStorage.setItem('table:columns:test', 'not-json')
+
+    const { result } = renderHook(() => useColumnVisibility('test', columns))
+
+    expect(result.current[0]).toEqual(defaults)
+  })
+})

--- a/apps/web/src/hooks/useColumnVisibility.js
+++ b/apps/web/src/hooks/useColumnVisibility.js
@@ -28,15 +28,14 @@ const loadVisibility = (tableId, defaults) => {
 
 export const useColumnVisibility = (tableId, columns) => {
   const defaults = toDefaults(columns)
-
-  const [columnVisibility, setColumnVisibilityState] = useState(() =>
+  const [columnVisibility, setColumnVisibility] = useState(() =>
     loadVisibility(tableId, defaults)
   )
 
-  const setColumnVisibility = next => {
+  const updateVisibility = next => {
     const resolved = typeof next === 'function' ? next(columnVisibility) : next
 
-    setColumnVisibilityState(resolved)
+    setColumnVisibility(resolved)
 
     const diff = diffFromDefaults(resolved, defaults)
 
@@ -47,5 +46,5 @@ export const useColumnVisibility = (tableId, columns) => {
     }
   }
 
-  return [columnVisibility, setColumnVisibility]
+  return [columnVisibility, updateVisibility]
 }

--- a/apps/web/src/hooks/useColumnVisibility.js
+++ b/apps/web/src/hooks/useColumnVisibility.js
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+
+import { localStorage } from '@/lib/storage'
+
+const buildKey = tableId => `table:columns:${tableId}`
+
+const toDefaults = columns =>
+  Object.fromEntries(
+    columns
+      .filter(col => col.accessorKey !== undefined)
+      .map(col => [col.accessorKey, col.hidden !== true])
+  )
+
+const diffFromDefaults = (visibility, defaults) =>
+  Object.fromEntries(
+    Object.entries(visibility).filter(([key, value]) => value !== defaults[key])
+  )
+
+const loadVisibility = (tableId, defaults) => {
+  try {
+    const stored = localStorage.get(buildKey(tableId))
+
+    return stored ? { ...defaults, ...JSON.parse(stored) } : defaults
+  } catch {
+    return defaults
+  }
+}
+
+export const useColumnVisibility = (tableId, columns) => {
+  const defaults = toDefaults(columns)
+
+  const [columnVisibility, setColumnVisibilityState] = useState(() =>
+    loadVisibility(tableId, defaults)
+  )
+
+  const setColumnVisibility = next => {
+    const resolved = typeof next === 'function' ? next(columnVisibility) : next
+
+    setColumnVisibilityState(resolved)
+
+    const diff = diffFromDefaults(resolved, defaults)
+
+    if (Object.keys(diff).length === 0) {
+      localStorage.remove(buildKey(tableId))
+    } else {
+      localStorage.set(buildKey(tableId), JSON.stringify(diff))
+    }
+  }
+
+  return [columnVisibility, setColumnVisibility]
+}

--- a/apps/web/src/pages/admin/Teams/TeamsPage.jsx
+++ b/apps/web/src/pages/admin/Teams/TeamsPage.jsx
@@ -15,11 +15,12 @@ import { Spinner } from '@/components/Spinner'
 import { ErrorState } from '@/components/states'
 import { ColumnVisibilityDropdown, Table } from '@/components/table'
 import { createOpenItem } from '@/components/table/contextMenuItems'
+import { useColumnVisibility } from '@/hooks/useColumnVisibility'
 import { useLocale } from '@/hooks/useLocale'
 import { useTableState } from '@/hooks/useTableState'
 import { useTeams } from '@/hooks/useTeam'
 
-import { defaultHiddenColumns, getColumns } from './columns'
+import { getColumns } from './columns'
 import { useManageTeams } from './useManageTeams'
 
 const coreRowModel = getCoreRowModel()
@@ -39,7 +40,10 @@ export const TeamsPage = () => {
   const { openCreateTeamDialog } = useManageTeams()
 
   const columns = getColumns(t, formatDate)
-  const [columnVisibility, setColumnVisibility] = useState(defaultHiddenColumns)
+  const [columnVisibility, setColumnVisibility] = useColumnVisibility(
+    'teams',
+    columns
+  )
   const [sorting, setSorting] = useState([])
 
   const viewTeam = team => navigate(`/admin/teams/${team.id}`)

--- a/apps/web/src/pages/admin/Teams/columns.jsx
+++ b/apps/web/src/pages/admin/Teams/columns.jsx
@@ -4,7 +4,8 @@ export const getColumns = (t, formatDate) => {
   return [
     {
       accessorKey: 'id',
-      header: label('id')
+      header: label('id'),
+      hidden: true
     },
     {
       accessorKey: 'name',
@@ -23,12 +24,8 @@ export const getColumns = (t, formatDate) => {
     {
       accessorKey: 'updatedAt',
       header: label('updatedAt'),
-      cell: info => formatDate(info.getValue())
+      cell: info => formatDate(info.getValue()),
+      hidden: true
     }
   ]
-}
-
-export const defaultHiddenColumns = {
-  id: false,
-  updatedAt: false
 }

--- a/apps/web/src/pages/admin/Users/UsersPage.jsx
+++ b/apps/web/src/pages/admin/Users/UsersPage.jsx
@@ -14,10 +14,11 @@ import { ErrorState } from '@/components/states'
 import { Table } from '@/components/table'
 import { createOpenItem } from '@/components/table/contextMenuItems'
 import { useUsers } from '@/hooks/useAdmin'
+import { useColumnVisibility } from '@/hooks/useColumnVisibility'
 import { useLocale } from '@/hooks/useLocale'
 import { useTableState } from '@/hooks/useTableState'
 
-import { defaultHiddenColumns, getColumns } from './columns'
+import { getColumns } from './columns'
 import { Filters } from './Filters'
 import { Toolbar } from './Toolbar'
 
@@ -35,7 +36,10 @@ export const UsersPage = () => {
     useUsers(apiParams)
 
   const columns = getColumns(t, formatDate)
-  const [columnVisibility, setColumnVisibility] = useState(defaultHiddenColumns)
+  const [columnVisibility, setColumnVisibility] = useColumnVisibility(
+    'users',
+    columns
+  )
   const [sorting, setSorting] = useState([])
   const [showFilters, setShowFilters] = useState(false)
 

--- a/apps/web/src/pages/admin/Users/columns.jsx
+++ b/apps/web/src/pages/admin/Users/columns.jsx
@@ -8,7 +8,8 @@ export const getColumns = (t, formatDate) => {
   return [
     {
       accessorKey: 'id',
-      header: label('id')
+      header: label('id'),
+      hidden: true
     },
     {
       accessorKey: 'name',
@@ -40,18 +41,14 @@ export const getColumns = (t, formatDate) => {
     {
       accessorKey: 'updatedAt',
       header: label('updatedAt'),
-      cell: info => formatDate(info.getValue())
+      cell: info => formatDate(info.getValue()),
+      hidden: true
     },
     {
       accessorKey: 'lastActive',
       header: label('lastActive'),
-      cell: info => <LastActiveBadge date={info.getValue()} />
+      cell: info => <LastActiveBadge date={info.getValue()} />,
+      hidden: true
     }
   ]
-}
-
-export const defaultHiddenColumns = {
-  id: false,
-  updatedAt: false,
-  lastActive: false
 }

--- a/apps/web/src/pages/owner/Admins/AdminsPage.jsx
+++ b/apps/web/src/pages/owner/Admins/AdminsPage.jsx
@@ -18,11 +18,12 @@ import {
   createOpenItem
 } from '@/components/table/contextMenuItems'
 import { useCurrentUser } from '@/hooks/useAuth'
+import { useColumnVisibility } from '@/hooks/useColumnVisibility'
 import { useLocale } from '@/hooks/useLocale'
 import { useAdmins } from '@/hooks/useOwner'
 import { useTableState } from '@/hooks/useTableState'
 
-import { defaultHiddenColumns, getColumns } from './columns'
+import { getColumns } from './columns'
 import { useInvite } from './useInvite'
 
 const coreRowModel = getCoreRowModel()
@@ -49,7 +50,10 @@ export const AdminsPage = () => {
   } = useInvite()
 
   const columns = getColumns(t, formatDate, me?.id)
-  const [columnVisibility, setColumnVisibility] = useState(defaultHiddenColumns)
+  const [columnVisibility, setColumnVisibility] = useColumnVisibility(
+    'admins',
+    columns
+  )
   const [sorting, setSorting] = useState([])
 
   const openAdminProfile = admin => navigate(`/owner/admins/${admin.id}`)

--- a/apps/web/src/pages/owner/Admins/columns.jsx
+++ b/apps/web/src/pages/owner/Admins/columns.jsx
@@ -8,7 +8,8 @@ export const getColumns = (t, formatDate, meId) => {
   return [
     {
       accessorKey: 'id',
-      header: label('id')
+      header: label('id'),
+      hidden: true
     },
     {
       accessorKey: 'name',
@@ -35,7 +36,8 @@ export const getColumns = (t, formatDate, meId) => {
       accessorKey: 'invitedBy',
       header: label('invitedBy'),
       accessorFn: row => getFullName(row?.inviter),
-      cell: info => info.getValue() ?? ''
+      cell: info => info.getValue() ?? '',
+      hidden: true
     },
     {
       accessorKey: 'invitedAt',
@@ -46,19 +48,14 @@ export const getColumns = (t, formatDate, meId) => {
     {
       accessorKey: 'updatedAt',
       header: label('updatedAt'),
-      cell: info => formatDate(info.getValue())
+      cell: info => formatDate(info.getValue()),
+      hidden: true
     },
     {
       accessorKey: 'lastActive',
       header: label('lastActive'),
-      cell: info => <LastActiveBadge date={info.getValue()} />
+      cell: info => <LastActiveBadge date={info.getValue()} />,
+      hidden: true
     }
   ]
-}
-
-export const defaultHiddenColumns = {
-  id: false,
-  invitedBy: false,
-  updatedAt: false,
-  lastActive: false
 }


### PR DESCRIPTION
[Feature]: Add `useColumnVisibility` hook that persists column visibility to localStorage per table, surviving page refreshes
[Improvement]: Co-locate default visibility with column definitions via `hidden: true` field, eliminating the separate `defaultHiddenColumns` export
[Improvement]: Store only the diff from defaults — if visibility matches defaults, the localStorage key is removed
[Feature]: Add tests for `useColumnVisibility` covering init, persistence, revert, restore on mount, updater function, and corrupt data fallback
[Fix]: Rename internal useState setter to resolve React Compiler lint warning about destructuring convention