### PR TITLE
Restore Codecov apt dependencies in CI workflows

### DIFF
--- a/.github/workflows/api-ci-ubuntu.yml
+++ b/.github/workflows/api-ci-ubuntu.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run tests with coverage
         run: bun run coverage
 
+      - name: Install dependencies for Codecov
+        run: apt-get update && apt-get install -y git curl gpg
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run tests with coverage
         run: NODE_ENV=test npx jest --coverage
 
+      - name: Install dependencies for Codecov
+        run: apt-get update && apt-get install -y git curl gpg
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
[Fix]: Restore missing apt-get step in both web and API CI workflows to install git, curl, and gpg required by codecov/codecov-action@v5