### PR TITLE
Extract bundle analysis into separate CI workflow

### DIFF
--- a/.github/workflows/api-ci-ubuntu.yml
+++ b/.github/workflows/api-ci-ubuntu.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'apps/api/**'
 
+env:
+  HUSKY: 0
+
 jobs:
   ci:
     name: Lint, Type Check & Tests

--- a/.github/workflows/web-bundle-analysis.yml
+++ b/.github/workflows/web-bundle-analysis.yml
@@ -1,0 +1,37 @@
+name: Web Bundle Analysis
+
+on:
+  push:
+    branches: [dev, main]
+    paths:
+      - 'apps/web/**'
+
+env:
+  HUSKY: 0
+
+jobs:
+  analyze-bundle:
+    name: Bundle Analysis (RelativeCI)
+    runs-on: ubuntu-latest
+    container: oven/bun:1.3.0
+    environment: web-test
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build and generate bundle stats
+        run: bun run bundle:analyze
+
+      - name: Upload bundle stats to RelativeCI
+        uses: relative-ci/agent-action@v3
+        with:
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          webpackStatsFile: apps/web/dist/webpack-stats.json

--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -60,30 +60,3 @@ jobs:
           files: apps/web/coverage/lcov.info
           flags: web
           fail_ci_if_error: true
-
-  analyze-bundle:
-    name: Bundle Analysis (RelativeCI)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
-    container: oven/bun:1.3.0
-    environment: web-test
-    defaults:
-      run:
-        working-directory: apps/web
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build and generate bundle stats
-        run: bun run bundle:analyze
-
-      - name: Upload bundle stats to RelativeCI
-        uses: relative-ci/agent-action@v3
-        with:
-          key: ${{ secrets.RELATIVE_CI_KEY }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          webpackStatsFile: apps/web/dist/webpack-stats.json


### PR DESCRIPTION
[Improvement]: Move bundle analysis job to a dedicated `web-bundle-analysis.yml` workflow triggered only on push, so it never appears as a skipped check on pull requests
[Improvement]: Add `HUSKY: 0` to `api-ci-ubuntu.yml` for consistency with the web CI workflow

## Test plan
- [ ] Open a PR and verify the bundle analysis check no longer appears
- [ ] Merge to `dev` and verify `Web Bundle Analysis` workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)