### PR TITLE
Remove staging build scripts and improve dev setup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,6 @@
     "reinstall": "bun clean && bun install",
     "dev": "bun --watch src/app.ts",
     "build": "NODE_ENV=production bun build src/app.ts --outdir dist --target bun --minify",
-    "build:staging": "NODE_ENV=staging bun build src/app.ts --outdir dist --target bun --sourcemap=external",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:custom": "bun src/data/migrations/custom/run.ts",
@@ -24,7 +23,6 @@
     "check": "bun run lint:fix && bun run tsc && bun run test",
     "emails": "email dev --dir src/emails --port 3001",
     "docker:build": "docker build -t smela-back --target production .",
-    "docker:build:staging": "docker build -t smela-back-staging --target staging .",
     "docker:test": "docker build -t smela-back-test --target test . && docker run --rm smela-back-test"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,6 @@
     "dev": "vite --mode development",
     "preview": "vite preview --mode production",
     "build": "vite build --mode production",
-    "build:staging": "vite build --mode staging",
     "test": "NODE_ENV=test jest",
     "coverage": "NODE_ENV=test jest --coverage",
     "e2e": "NODE_ENV=test bunx playwright test -x",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "dev:api": "bun run --filter @smela/api dev",
     "dev": "bun run dev:api & bun run dev:web",
     "dev:tmux": "bash scripts/dev.sh",
+    "dev:tmux:kill": "tmux kill-session -t smela-dev",
     "check:web": "bun run --filter @smela/web check",
     "check:api": "bun run --filter @smela/api check",
-    "check": "bun run check:api & bun run check:web & wait $(jobs -p)"
+    "check": "bun run check:api & bun run check:web & wait $(jobs -p)",
+    "e2e": "bun run --filter @smela/api e2e & bun run --filter @smela/web e2e & wait $(jobs -p)"
   }
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 SESSION="smela-dev"
 
+tmux kill-session -t $SESSION 2>/dev/null || true
 tmux new-session -d -s $SESSION -x "$(tput cols)" -y "$(tput lines)"
 
 tmux split-window -h -t $SESSION
+tmux split-window -v -t $SESSION:0.1
 
 tmux send-keys -t $SESSION:0.0 "cd apps/api && bun run dev" Enter
 tmux send-keys -t $SESSION:0.1 "cd apps/web && bun run dev" Enter
+tmux send-keys -t $SESSION:0.2 "bun run --filter @smela/api db:ui" Enter
 
 tmux attach-session -t $SESSION

--- a/smela.code-workspace
+++ b/smela.code-workspace
@@ -4,4 +4,9 @@
     { "path": "apps/api", "name": "api" },
     { "path": "apps/web", "name": "web" },
   ],
+  "settings": {
+    "files.exclude": {
+      "apps": true
+    }
+  }
 }


### PR DESCRIPTION
[Improvement]: Remove staging build scripts from app-level package.json files to simplify CI configuration
[Feature]: Add dev:tmux:kill script to cleanly terminate the smela-dev tmux session
[Feature]: Add e2e script to run both api and web e2e tests in parallel
[Improvement]: Hide apps/ folder in workspace root to avoid duplication with dedicated api/web folders
[Improvement]: Improve dev.sh tmux session setup for better pane layout