### PR TITLE
Upgrade Bun to 1.3.11

### DIFF
--- a/.github/workflows/api-ci-ubuntu.yml
+++ b/.github/workflows/api-ci-ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
   ci:
     name: Lint, Type Check & Tests
     runs-on: ubuntu-latest
-    container: oven/bun:1.3.0
+    container: oven/bun:1.3.11
     environment: api-test
     defaults:
       run:

--- a/.github/workflows/web-bundle-analysis.yml
+++ b/.github/workflows/web-bundle-analysis.yml
@@ -13,7 +13,7 @@ jobs:
   analyze-bundle:
     name: Bundle Analysis (RelativeCI)
     runs-on: ubuntu-latest
-    container: oven/bun:1.3.0
+    container: oven/bun:1.3.11
     environment: web-test
     defaults:
       run:

--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
   ci:
     name: Format, Lint & Tests
     runs-on: ubuntu-latest
-    container: oven/bun:1.3.0
+    container: oven/bun:1.3.11
     environment: web-test
     defaults:
       run:

--- a/apps/api/src/__tests__/module-mocker.ts
+++ b/apps/api/src/__tests__/module-mocker.ts
@@ -7,8 +7,12 @@ export interface MockResult {
 }
 
 /**
- * Due to an issue with Bun (https://github.com/oven-sh/bun/issues/7823 and https://github.com/oven-sh/bun/issues/12823), we need to manually restore mocked modules
- * after we're done. We do this by setting the mocked value to the original module.
+ * Due to a Bun bug, mock.module() operates on a global module registry with no per-file or
+ * per-test scoping, so mocks leak across test files and mock.restore() does not reset them.
+ * Issues: https://github.com/oven-sh/bun/issues/7823, https://github.com/oven-sh/bun/issues/12823
+ * Fix in progress (not yet merged): https://github.com/oven-sh/bun/pull/25844
+ *
+ * This class works around the issue by re-applying the original module after each test.
  *
  * When setting up a test that will mock a module, the block should add this:
  * const moduleMocker = new ModuleMocker(import.meta.url)


### PR DESCRIPTION
[Improvement]: Upgrade Bun runtime from 1.3.0 to 1.3.11 in all CI workflow containers
[Improvement]: Clarify ModuleMocker comment with root cause explanation and link to fix PR oven-sh/bun#25844