### PR TITLE
Improve tmux dev script with kill flag and pane names

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:api": "bun run --filter @smela/api dev",
     "dev": "bun run dev:api & bun run dev:web",
     "dev:tmux": "bash scripts/dev.sh",
-    "dev:tmux:kill": "tmux kill-session -t smela-dev",
+    "dev:tmux:kill": "bash scripts/dev.sh --kill",
     "check:web": "bun run --filter @smela/web check",
     "check:api": "bun run --filter @smela/api check",
     "check": "bun run check:api & bun run check:web & wait $(jobs -p)",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 SESSION="smela-dev"
 
-tmux kill-session -t $SESSION 2>/dev/null || true
+if [[ "$1" == "--kill" ]]; then
+  tmux kill-session -t $SESSION 2>/dev/null || true
+  exit 0
+fi
+
+if tmux has-session -t $SESSION 2>/dev/null; then
+  tmux attach-session -t $SESSION
+  exit 0
+fi
+
 tmux new-session -d -s $SESSION -x "$(tput cols)" -y "$(tput lines)"
 
 tmux split-window -h -t $SESSION
 tmux split-window -v -t $SESSION:0.1
+
+tmux select-pane -t $SESSION:0.0 -T "smela API"
+tmux select-pane -t $SESSION:0.1 -T "smela Web"
+tmux select-pane -t $SESSION:0.2 -T "Drizzle Studio"
 
 tmux send-keys -t $SESSION:0.0 "cd apps/api && bun run dev" Enter
 tmux send-keys -t $SESSION:0.1 "cd apps/web && bun run dev" Enter


### PR DESCRIPTION
[Improvement]: Add \`--kill\` flag to \`dev.sh\` so \`dev:tmux:kill\` delegates to the script, removing the hardcoded session name from \`package.json\`
[Improvement]: Attach to an existing tmux session instead of killing and recreating it on repeated \`dev:tmux\` invocations
[Improvement]: Set meaningful pane titles — \`smela API\`, \`smela Web\`, \`Drizzle Studio\` — for easier orientation in the tmux layout