### PR TITLE
Remove Node.js from web prerequisites

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -10,7 +10,6 @@ React SPA with a solid, well-designed architecture for a smooth user experience.
 ## 📋 Prerequisites
 
 - [Git](https://git-scm.com/) version control
-- [Node.js](https://nodejs.org) (v22 or higher)
 - [Bun](https://bun.sh/) runtime (latest version)
 
 See [CI workflow](../../.github/workflows/web-ci-ubuntu.yml) for more details.


### PR DESCRIPTION
[Improvement]: Remove Node.js prerequisite from web README since the project runs entirely on Bun and CI uses the official Bun container without Node.js