### PR TITLE
Fix E2E enum casing and update root scripts

### DIFF
--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -89,8 +89,8 @@ test.describe.serial('Authentication: User Lifecycle', () => {
             fn === user.firstName &&
             ln === user.lastName &&
             email === user.email &&
-            status === UserStatus.NEW &&
-            role === Role.USER
+            status === UserStatus.New &&
+            role === Role.User
           )
         }
       },
@@ -108,8 +108,8 @@ test.describe.serial('Authentication: User Lifecycle', () => {
             fn === user.firstName &&
             ln === user.lastName &&
             email === user.email &&
-            status === UserStatus.VERIFIED &&
-            role === Role.USER
+            status === UserStatus.Verified &&
+            role === Role.User
           )
         }
       }
@@ -287,8 +287,8 @@ test.describe('Authentication: General', () => {
           fn === firstName &&
           ln === lastName &&
           email === testEmail &&
-          status === UserStatus.NEW &&
-          role === Role.USER
+          status === UserStatus.New &&
+          role === Role.User
         )
       }
     })

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "clean": "bun run --filter @smela/api clean & bun run --filter @smela/web clean & rm -rf node_modules & wait",
     "reinstall": "bun run clean && bun install",
     "prepare": "husky",
-    "lint": "bun run --filter @smela/api lint & bun run --filter @smela/web lint & wait $(jobs -p)",
-    "lint:fix": "bun run --filter @smela/api lint:fix & bun run --filter @smela/web lint:fix & wait $(jobs -p)",
     "dev:web": "bun run --filter @smela/web dev",
     "dev:api": "bun run --filter @smela/api dev",
     "dev": "bun run dev:api & bun run dev:web",
@@ -25,6 +23,7 @@
     "check:web": "bun run --filter @smela/web check",
     "check:api": "bun run --filter @smela/api check",
     "check": "bun run check:api & bun run check:web & wait $(jobs -p)",
-    "e2e": "bun run --filter @smela/api e2e & bun run --filter @smela/web e2e & wait $(jobs -p)"
+    "e2e:web": "bun run --filter @smela/api dev & bun run --filter @smela/web e2e & wait $(jobs -p)",
+    "e2e:web:ui": "bun run --filter @smela/api dev & bun run --filter @smela/web e2e:ui & wait $(jobs -p)"
   }
 }


### PR DESCRIPTION
[Fix]: Update E2E auth tests to use PascalCase enum values matching renamed \`Role\` and \`UserStatus\` enums
[Improvement]: Replace root-level \`e2e\` script with \`e2e:web\` and \`e2e:web:ui\` for clearer web-specific test execution
[Improvement]: Remove duplicate root-level \`lint\` and \`lint:fix\` scripts (covered by individual app scripts)