### PR TITLE
Clean up vitest and E2E config

### DIFF
--- a/apps/web/e2e/config/fixtures.js
+++ b/apps/web/e2e/config/fixtures.js
@@ -1,6 +1,7 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { test as base } from '@playwright/test'
-import fs from 'fs'
-import path from 'path'
 
 import { HttpStatus } from '../../src/lib/net'
 import { LOGIN_PATH } from '../../src/services/backend/paths'

--- a/apps/web/e2e/config/globalSetup.js
+++ b/apps/web/e2e/config/globalSetup.js
@@ -23,8 +23,10 @@ const globalSetup = () => {
   const missing = requiredVars.filter(v => !process.env[v])
 
   if (missing.length > 0) {
+    const list = missing.map(v => `  - ${v}`).join('\n')
+
     throw new Error(
-      `Missing required environment variables:\n${missing.map(v => `  - ${v}`).join('\n')}\n\nCheck your .env.test file.`
+      `Missing required environment variables:\n${list}\n\nCheck your .env.test file.`
     )
   }
 }

--- a/apps/web/vitest.config.js
+++ b/apps/web/vitest.config.js
@@ -7,19 +7,13 @@ import { defineConfig } from 'vitest/config'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: ['babel-plugin-react-compiler']
-      }
-    })
-  ],
+  plugins: [react()],
   test: {
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/tests/setup.js'],
     include: ['**/__tests__/**/*.{js,jsx}', '**/*.{spec,test}.{js,jsx}'],
-    exclude: ['node_modules', 'e2e', 'tests-examples'],
+    exclude: ['node_modules', 'e2e'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'],
@@ -48,7 +42,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
-      '@components': path.resolve(__dirname, 'src/components'),
       $: path.resolve(__dirname, 'public')
     }
   }


### PR DESCRIPTION
[Improvement]: Remove React Compiler Babel plugin from Vitest — build-time optimization has no value in tests
[Improvement]: Drop unused \`@components\` path alias and leftover \`tests-examples\` exclusion from Vitest config
[Improvement]: Use \`node:\` protocol for built-in imports in E2E fixtures
[Improvement]: Extract nested template literal in globalSetup error message for readability