### PR TITLE
Add e2e tmux script, postinstall i18n sync, and fix columns menu

### DIFF
--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -38,10 +38,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Sync locale files
-        run: bun run sync
-        working-directory: packages/i18n
-
       - name: Check formatting
         run: bun run format
 

--- a/apps/web/e2e/owner-admins-management.spec.js
+++ b/apps/web/e2e/owner-admins-management.spec.js
@@ -48,10 +48,13 @@ test.describe('Owner: Admins Page', () => {
       page.getByRole('columnheader', { name: t.table.users.id })
     ).not.toBeVisible()
 
+    const menu = page.getByRole('menu', { name: t.table.column_plural })
+
     // Show the ID column
     await columnsButton.click()
     await page.getByRole('menuitemcheckbox', { name: t.table.users.id }).click()
-    await columnsButton.click()
+    await page.keyboard.press('Escape')
+    await expect(menu).not.toBeVisible()
 
     // Header and first data cell in same column position must align
     await expect(
@@ -67,7 +70,8 @@ test.describe('Owner: Admins Page', () => {
     // Hide the ID column again
     await columnsButton.click()
     await page.getByRole('menuitemcheckbox', { name: t.table.users.id }).click()
-    await columnsButton.click()
+    await page.keyboard.press('Escape')
+    await expect(menu).not.toBeVisible()
 
     await expect(
       page.getByRole('columnheader', { name: t.table.users.id })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clean": "bun run --filter @smela/api clean & bun run --filter @smela/web clean & rm -rf node_modules & wait",
     "reinstall": "bun run clean && bun install",
     "prepare": "husky",
+    "postinstall": "bun run --filter @smela/i18n sync",
     "dev:web": "bun run --filter @smela/i18n sync:watch & bun run --filter @smela/web dev",
     "dev:api": "bun run --filter @smela/api dev",
     "dev": "bun run dev:api & bun run dev:web",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "check:web": "bun run --filter @smela/web check",
     "check:api": "bun run --filter @smela/api check",
     "check": "bun run check:api & bun run check:web & wait $(jobs -p)",
-    "e2e:web": "bun run --filter @smela/api dev & bun run --filter @smela/web e2e & wait $(jobs -p)",
-    "e2e:web:ui": "bun run --filter @smela/api dev & bun run --filter @smela/web e2e:ui & wait $(jobs -p)"
+    "e2e:web": "bash scripts/e2e.sh",
+    "e2e:web:ui": "bash scripts/e2e.sh --ui",
+    "e2e:web:kill": "bash scripts/e2e.sh --kill"
   }
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+SESSION="smela-e2e"
+E2E_CMD="e2e"
+
+if [[ "$1" == "--ui" ]]; then
+  E2E_CMD="e2e:ui"
+elif [[ "$1" == "--kill" ]]; then
+  tmux kill-session -t $SESSION 2>/dev/null || true
+  exit 0
+fi
+
+if tmux has-session -t $SESSION 2>/dev/null; then
+  tmux kill-session -t $SESSION
+fi
+
+tmux new-session -d -s $SESSION -x "$(tput cols)" -y "$(tput lines)"
+tmux split-window -h -t $SESSION
+
+tmux select-pane -t $SESSION:0.0 -T "smela API"
+tmux select-pane -t $SESSION:0.1 -T "smela E2E"
+
+tmux send-keys -t $SESSION:0.0 "bun run --cwd apps/api dev" Enter
+tmux send-keys -t $SESSION:0.1 "bun run --cwd apps/web $E2E_CMD" Enter
+
+tmux attach-session -t $SESSION


### PR DESCRIPTION
[Improvement]: Add \`postinstall\` script to root \`package.json\` so locale files sync automatically after \`bun install\`
[Improvement]: Remove redundant "Sync locale files" CI step since \`postinstall\` now covers it during \`bun install --frozen-lockfile\`
[Feature]: Add \`scripts/e2e.sh\` tmux script that runs API and E2E in split panes with full log output, replacing the collapsed \`--filter\` parallel variant
[Fix]: Replace \`columnsButton.click()\` with \`Escape\` + menu visibility assertion to reliably close the Base UI dropdown in the E2E column toggle test