### PR TITLE
Update READMEs with prerequisites and packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Starter kit for full-stack web apps
 
-## Apps
+## 📋 Prerequisites
+
+- [Git](https://git-scm.com/)
+- [Bun](https://bun.sh/)
+- [tmux](https://github.com/tmux/tmux/wiki)
+
+## 💻 Apps
 
 - [API](apps/api/README.md)
 - [Web](apps/web/README.md)
+
+## 📦 Packages
+
+- [e2e](packages/e2e/README.md)
+- [i18n](packages/i18n)

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -9,9 +9,9 @@ Layered monolithic REST API with authentication and RBAC, focused on security an
 
 ## 📋 Prerequisites
 
-- [Git](https://git-scm.com/) version control
+Besides [root prerequisites](../../README.md#-prerequisites) we need:
+
 - [Docker](https://www.docker.com/) for running PostgreSQL
-- [Bun](https://bun.sh/) runtime (latest version)
 - Email service account ([Resend](https://resend.com/) for production, [Ethereal](https://ethereal.email/) for development)
 
 See [CI workflow](../../.github/workflows/api-ci-ubuntu.yml) for more details.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -9,8 +9,8 @@ React SPA with a solid, well-designed architecture for a smooth user experience.
 
 ## 📋 Prerequisites
 
-- [Git](https://git-scm.com/) version control
-- [Bun](https://bun.sh/) runtime (latest version)
+No additional prerequisites beyond
+[root requirements](../../README.md#-prerequisites).
 
 See [CI workflow](../../.github/workflows/web-ci-ubuntu.yml) for more details.
 


### PR DESCRIPTION
[Improvement]: Add root Prerequisites section to README.md so Git, Bun, and tmux are documented as the baseline for all apps and packages
[Improvement]: Add Packages section to root README.md linking to e2e and i18n packages
[Improvement]: Update API README to reference root prerequisites instead of duplicating Git/Bun entries
[Improvement]: Update Web README to replace duplicated prerequisites with a link to root requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)