### PR TITLE
Add shared ESLint config package and clean up web config

### DIFF
--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'apps/web/**'
       - 'packages/i18n/**'
+      - 'packages/eslint/**'
   push:
     branches: [dev, main]
     paths:
       - 'apps/web/**'
       - 'packages/i18n/**'
+      - 'packages/eslint/**'
 
 concurrency:
   group: web-ci-${{ github.ref }}

--- a/apps/web/.vscode/settings.json
+++ b/apps/web/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "eslint.options": {
+    "settings": {
+      "import/resolver": {
+        "node": {
+          "paths": ["src"]
+        },
+        "alias": {
+          "map": [["@", "./src"]],
+          "extensions": [".js", ".jsx"]
+        }
+      }
+    }
+  }
+}

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -99,7 +99,7 @@ export default [
   },
   {
     // Vitest
-    files: ['**/*.test.{js,jsx}', '**/*.spec.{js,jsx}', 'src/tests/setup.js'],
+    files: ['**/*.test.{js,jsx}', 'src/tests/**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
@@ -115,14 +115,13 @@ export default [
     files: ['e2e/**/*.{js,jsx}', 'playwright.config.js'],
     languageOptions: {
       globals: {
-        ...globals.node,
-        ...globals.browser
+        ...globals.node
       }
     }
   },
   {
     // Build and config files
-    files: ['vite.config.js', '*.config.js', '*.config.mjs'],
+    files: ['*.config.js'],
     languageOptions: {
       globals: {
         ...globals.node

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,102 +1,10 @@
-import js from '@eslint/js'
-import tanstackQuery from '@tanstack/eslint-plugin-query'
-import reactPlugin from 'eslint-plugin-react'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import simpleImportSort from 'eslint-plugin-simple-import-sort'
+import { reactConfig } from '@smela/eslint/react'
 import storybook from 'eslint-plugin-storybook'
 import globals from 'globals'
 
 export default [
   { ignores: ['dist'] },
-  {
-    files: ['**/*.{js,jsx}'],
-    languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: { jsx: true },
-        sourceType: 'module'
-      }
-    },
-    plugins: {
-      react: reactPlugin,
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-      'simple-import-sort': simpleImportSort,
-      '@tanstack/query': tanstackQuery
-    },
-    rules: {
-      ...js.configs.recommended.rules,
-      ...reactPlugin.configs.recommended.rules,
-      ...reactHooks.configs['recommended-latest'].rules,
-      ...tanstackQuery.configs.recommended.rules,
-
-      'react/react-in-jsx-scope': 'off',
-      'react/prop-types': 'off',
-      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true }
-      ],
-      'simple-import-sort/imports': 'error',
-      'simple-import-sort/exports': 'error',
-      'padding-line-between-statements': [
-        'error',
-        // Keep a line before return
-        { blankLine: 'always', prev: '*', next: 'return' },
-        // Blank lines after imports, vars
-        {
-          blankLine: 'always',
-          prev: ['import', 'const', 'let', 'var'],
-          next: '*'
-        },
-        {
-          blankLine: 'any',
-          prev: ['import', 'const', 'let', 'var'],
-          next: ['import', 'const', 'let', 'var']
-        },
-        // Add spacing before if, for, while, switch
-        {
-          blankLine: 'always',
-          prev: '*',
-          next: ['if', 'for', 'while', 'switch', 'try']
-        },
-        // Add spacing after blocks and functions
-        {
-          blankLine: 'always',
-          prev: ['block', 'block-like', 'function', 'multiline-expression'],
-          next: '*'
-        },
-        // Optional: before function declarations (helps in React utils)
-        {
-          blankLine: 'always',
-          prev: '*',
-          next: 'function'
-        }
-      ],
-      'no-console': ['warn', { allow: ['warn', 'error'] }],
-      'prefer-const': 'error',
-      'no-unsafe-optional-chaining': 'error',
-      'react/jsx-no-useless-fragment': 'error',
-      curly: ['error', 'all']
-    },
-    settings: {
-      react: {
-        version: 'detect'
-      },
-      'import/resolver': {
-        node: {
-          paths: ['src']
-        },
-        alias: {
-          map: [['@', './src']],
-          extensions: ['.js', '.jsx', '.ts', '.tsx']
-        }
-      }
-    }
-  },
+  ...reactConfig,
   {
     // Vitest
     files: ['**/*.test.{js,jsx}', 'src/tests/**/*.{js,jsx}'],

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,32 +1,19 @@
-import { reactConfig } from '@smela/eslint/react'
+import {
+  playwrightConfig,
+  reactConfig,
+  shadcnConfig,
+  vitestConfig
+} from '@smela/eslint'
 import storybook from 'eslint-plugin-storybook'
 import globals from 'globals'
 
 export default [
   { ignores: ['dist'] },
   ...reactConfig,
-  {
-    // Vitest
-    files: ['**/*.test.{js,jsx}', 'src/tests/**/*.{js,jsx}'],
-    languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      globals: {
-        ...globals.vitest,
-        ...globals.node,
-        global: true
-      }
-    }
-  },
-  {
-    // Playwright
-    files: ['e2e/**/*.{js,jsx}', 'playwright.config.js'],
-    languageOptions: {
-      globals: {
-        ...globals.node
-      }
-    }
-  },
+  ...shadcnConfig,
+  ...vitestConfig,
+  ...playwrightConfig,
+  ...storybook.configs['flat/recommended'],
   {
     // Build and config files
     files: ['*.config.js'],
@@ -34,14 +21,6 @@ export default [
       globals: {
         ...globals.node
       }
-    }
-  },
-  ...storybook.configs['flat/recommended'],
-  {
-    // shadcn/ui components export both components and variants
-    files: ['src/components/ui/**/*.{js,jsx}'],
-    rules: {
-      'react-refresh/only-export-components': 'off'
     }
   }
 ]

--- a/apps/web/jsconfig.json
+++ b/apps/web/jsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "$/*": ["public/*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,7 +59,7 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
+    "@smela/eslint": "workspace:*",
     "@faker-js/faker": "^10.3.0",
     "@hookform/devtools": "^4.4.0",
     "@playwright/test": "^1.58.2",
@@ -67,7 +67,6 @@
     "@smela/e2e": "workspace:*",
     "@storybook/addon-onboarding": "^10.2.10",
     "@storybook/react-vite": "^10.2.10",
-    "@tanstack/eslint-plugin-query": "^5.91.2",
     "@tanstack/react-query-devtools": "^5.91.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
@@ -79,10 +78,6 @@
     "@vitest/coverage-istanbul": "^4.1.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.39.2",
-    "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.4.24",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-storybook": "^10.2.10",
     "globals": "^17.0.0",
     "lint-staged": "^16.2.6",

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -85,8 +85,7 @@ export default defineConfig({
   ].filter(Boolean),
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
-      $: path.resolve(__dirname, 'public')
+      '@': path.resolve(__dirname, 'src')
     }
   }
 })

--- a/bun.lock
+++ b/bun.lock
@@ -78,15 +78,14 @@
         "yup": "^1.7.1",
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.2",
         "@faker-js/faker": "^10.3.0",
         "@hookform/devtools": "^4.4.0",
         "@playwright/test": "^1.58.2",
         "@sentry/vite-plugin": "^4.9.1",
         "@smela/e2e": "workspace:*",
+        "@smela/eslint": "workspace:*",
         "@storybook/addon-onboarding": "^10.2.10",
         "@storybook/react-vite": "^10.2.10",
-        "@tanstack/eslint-plugin-query": "^5.91.2",
         "@tanstack/react-query-devtools": "^5.91.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -98,10 +97,6 @@
         "@vitest/coverage-istanbul": "^4.1.2",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^9.39.2",
-        "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "eslint-plugin-react-refresh": "^0.4.24",
-        "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-storybook": "^10.2.10",
         "globals": "^17.0.0",
         "lint-staged": "^16.2.6",
@@ -122,15 +117,34 @@
       "dependencies": {
         "mailisk": "^2.2.2",
       },
+      "devDependencies": {
+        "@smela/eslint": "workspace:*",
+        "eslint": "^9.39.2",
+      },
       "peerDependencies": {
         "@playwright/test": "^1.58.2",
+      },
+    },
+    "packages/eslint": {
+      "name": "@smela/eslint",
+      "version": "0.0.1",
+      "dependencies": {
+        "@eslint/js": "^9.39.2",
+        "@tanstack/eslint-plugin-query": "^5.91.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
+        "globals": "^17.0.0",
       },
     },
     "packages/i18n": {
       "name": "@smela/i18n",
       "version": "0.0.1",
       "devDependencies": {
+        "@smela/eslint": "workspace:*",
         "chokidar": "^5.0.0",
+        "eslint": "^9.39.2",
       },
       "peerDependencies": {
         "i18next": "^25.8.11",
@@ -803,6 +817,8 @@
     "@smela/api": ["@smela/api@workspace:apps/api"],
 
     "@smela/e2e": ["@smela/e2e@workspace:packages/e2e"],
+
+    "@smela/eslint": ["@smela/eslint@workspace:packages/eslint"],
 
     "@smela/i18n": ["@smela/i18n@workspace:packages/i18n"],
 
@@ -2260,7 +2276,7 @@
 
     "reserved-identifiers": ["reserved-identifiers@1.2.0", "", {}, "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw=="],
 
-    "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+    "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -2742,9 +2758,15 @@
 
     "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "@smela/e2e/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "@smela/i18n/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
     "@smela/web/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
     "@storybook/csf-plugin/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
+    "@storybook/react-vite/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "@stylistic/eslint-plugin/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -2804,6 +2826,8 @@
 
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
+    "babel-plugin-macros/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
+
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
@@ -2845,8 +2869,6 @@
     "eslint-plugin-react/eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
     "eslint-plugin-react/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "eslint-plugin-react/resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
@@ -2921,6 +2943,8 @@
     "react-docgen/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "react-docgen/doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "react-docgen/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "react-email/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -3091,6 +3115,38 @@
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "@sentry/cli/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "@smela/e2e/eslint/@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@smela/e2e/eslint/@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@smela/e2e/eslint/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@smela/e2e/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@smela/e2e/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "@smela/e2e/eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "@smela/e2e/eslint/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "@smela/e2e/eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@smela/i18n/eslint/@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@smela/i18n/eslint/@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@smela/i18n/eslint/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@smela/i18n/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@smela/i18n/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "@smela/i18n/eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "@smela/i18n/eslint/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "@smela/i18n/eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@smela/web/eslint/@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
 
@@ -3436,6 +3492,14 @@
 
     "@sentry/cli/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "@smela/e2e/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@smela/e2e/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "@smela/i18n/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@smela/i18n/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
     "@smela/web/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@smela/web/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -3465,6 +3529,10 @@
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@smela/e2e/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@smela/i18n/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@smela/web/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "apps/web",
     "apps/api",
     "packages/e2e",
-    "packages/i18n"
+    "packages/i18n",
+    "packages/eslint"
   ],
   "engines": {
     "bun": ">=1"

--- a/packages/e2e/eslint.config.js
+++ b/packages/e2e/eslint.config.js
@@ -1,0 +1,3 @@
+import { baseConfig } from '@smela/eslint/base'
+
+export default [...baseConfig]

--- a/packages/e2e/eslint.config.js
+++ b/packages/e2e/eslint.config.js
@@ -1,3 +1,3 @@
-import { baseConfig } from '@smela/eslint/base'
+import { baseConfig } from '@smela/eslint'
 
 export default [...baseConfig]

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -7,7 +7,9 @@
     "clean": "rm -rf node_modules",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "check": "bun run format:fix"
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "check": "bun run format:fix && bun run lint:fix"
   },
   "exports": {
     "./config": "./src/config.js",
@@ -17,6 +19,10 @@
   },
   "dependencies": {
     "mailisk": "^2.2.2"
+  },
+  "devDependencies": {
+    "@smela/eslint": "workspace:*",
+    "eslint": "^9.39.2"
   },
   "peerDependencies": {
     "@playwright/test": "^1.58.2"

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@smela/eslint",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./base": "./src/base.js",
+    "./react": "./src/react.js"
+  },
+  "dependencies": {
+    "@eslint/js": "^9.39.2",
+    "@tanstack/eslint-plugin-query": "^5.91.2",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "globals": "^17.0.0"
+  }
+}

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -4,8 +4,12 @@
   "private": true,
   "type": "module",
   "exports": {
+    ".": "./src/index.js",
     "./base": "./src/base.js",
-    "./react": "./src/react.js"
+    "./react": "./src/react.js",
+    "./vitest": "./src/vitest.js",
+    "./playwright": "./src/playwright.js",
+    "./shadcn": "./src/shadcn.js"
   },
   "dependencies": {
     "@eslint/js": "^9.39.2",

--- a/packages/eslint/src/base.js
+++ b/packages/eslint/src/base.js
@@ -1,0 +1,57 @@
+import js from '@eslint/js'
+import simpleImportSort from 'eslint-plugin-simple-import-sort'
+import globals from 'globals'
+
+export const baseRules = {
+  ...js.configs.recommended.rules,
+  'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  'no-console': ['warn', { allow: ['warn', 'error'] }],
+  'prefer-const': 'error',
+  'no-unsafe-optional-chaining': 'error',
+  curly: ['error', 'all'],
+  'simple-import-sort/imports': 'error',
+  'simple-import-sort/exports': 'error',
+  'padding-line-between-statements': [
+    'error',
+    { blankLine: 'always', prev: '*', next: 'return' },
+    {
+      blankLine: 'always',
+      prev: ['import', 'const', 'let', 'var'],
+      next: '*'
+    },
+    {
+      blankLine: 'any',
+      prev: ['import', 'const', 'let', 'var'],
+      next: ['import', 'const', 'let', 'var']
+    },
+    {
+      blankLine: 'always',
+      prev: '*',
+      next: ['if', 'for', 'while', 'switch', 'try']
+    },
+    {
+      blankLine: 'always',
+      prev: ['block', 'block-like', 'function', 'multiline-expression'],
+      next: '*'
+    },
+    { blankLine: 'always', prev: '*', next: 'function' }
+  ]
+}
+
+export const basePlugins = {
+  'simple-import-sort': simpleImportSort
+}
+
+/** Shared flat-config for plain JS/ESM Node packages. */
+export const baseConfig = [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.node
+    },
+    plugins: basePlugins,
+    rules: baseRules
+  }
+]

--- a/packages/eslint/src/base.js
+++ b/packages/eslint/src/base.js
@@ -42,7 +42,6 @@ export const basePlugins = {
   'simple-import-sort': simpleImportSort
 }
 
-/** Shared flat-config for plain JS/ESM Node packages. */
 export const baseConfig = [
   {
     files: ['**/*.js'],

--- a/packages/eslint/src/index.js
+++ b/packages/eslint/src/index.js
@@ -1,0 +1,5 @@
+export { baseConfig, basePlugins, baseRules } from './base.js'
+export { playwrightConfig } from './playwright.js'
+export { reactConfig } from './react.js'
+export { shadcnConfig } from './shadcn.js'
+export { vitestConfig } from './vitest.js'

--- a/packages/eslint/src/playwright.js
+++ b/packages/eslint/src/playwright.js
@@ -3,7 +3,7 @@ import globals from 'globals'
 /** Shared Playwright globals override — covers e2e test files and config. */
 export const playwrightConfig = [
   {
-    files: ['e2e/**/*.{js,jsx}', 'playwright.config.js'],
+    files: ['e2e/**/*.{js,jsx}', '**/playwright.config.js'],
     languageOptions: {
       globals: {
         ...globals.node

--- a/packages/eslint/src/playwright.js
+++ b/packages/eslint/src/playwright.js
@@ -1,0 +1,13 @@
+import globals from 'globals'
+
+/** Shared Playwright globals override — covers e2e test files and config. */
+export const playwrightConfig = [
+  {
+    files: ['e2e/**/*.{js,jsx}', 'playwright.config.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node
+      }
+    }
+  }
+]

--- a/packages/eslint/src/playwright.js
+++ b/packages/eslint/src/playwright.js
@@ -1,6 +1,5 @@
 import globals from 'globals'
 
-/** Shared Playwright globals override — covers e2e test files and config. */
 export const playwrightConfig = [
   {
     files: ['e2e/**/*.{js,jsx}', '**/playwright.config.js'],

--- a/packages/eslint/src/react.js
+++ b/packages/eslint/src/react.js
@@ -51,7 +51,7 @@ export const reactConfig = [
         },
         alias: {
           map: [['@', './src']],
-          extensions: ['.js', '.jsx', '.ts', '.tsx']
+          extensions: ['.js', '.jsx']
         }
       }
     }

--- a/packages/eslint/src/react.js
+++ b/packages/eslint/src/react.js
@@ -1,0 +1,59 @@
+import tanstackQuery from '@tanstack/eslint-plugin-query'
+import reactPlugin from 'eslint-plugin-react'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import globals from 'globals'
+
+import { basePlugins, baseRules } from './base.js'
+
+/** Shared flat-config for React/Vite apps. */
+export const reactConfig = [
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.browser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module'
+      }
+    },
+    plugins: {
+      ...basePlugins,
+      react: reactPlugin,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+      '@tanstack/query': tanstackQuery
+    },
+    rules: {
+      ...baseRules,
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooks.configs['recommended-latest'].rules,
+      ...tanstackQuery.configs.recommended.rules,
+
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true }
+      ],
+      'react/jsx-no-useless-fragment': 'error'
+    },
+    settings: {
+      react: {
+        version: 'detect'
+      },
+      'import/resolver': {
+        node: {
+          paths: ['src']
+        },
+        alias: {
+          map: [['@', './src']],
+          extensions: ['.js', '.jsx', '.ts', '.tsx']
+        }
+      }
+    }
+  }
+]

--- a/packages/eslint/src/react.js
+++ b/packages/eslint/src/react.js
@@ -44,15 +44,6 @@ export const reactConfig = [
     settings: {
       react: {
         version: 'detect'
-      },
-      'import/resolver': {
-        node: {
-          paths: ['src']
-        },
-        alias: {
-          map: [['@', './src']],
-          extensions: ['.js', '.jsx']
-        }
       }
     }
   }

--- a/packages/eslint/src/react.js
+++ b/packages/eslint/src/react.js
@@ -6,7 +6,6 @@ import globals from 'globals'
 
 import { basePlugins, baseRules } from './base.js'
 
-/** Shared flat-config for React/Vite apps. */
 export const reactConfig = [
   {
     files: ['**/*.{js,jsx}'],

--- a/packages/eslint/src/shadcn.js
+++ b/packages/eslint/src/shadcn.js
@@ -1,4 +1,3 @@
-/** Shared shadcn/ui override — components export both components and variants. */
 export const shadcnConfig = [
   {
     files: ['src/components/ui/**/*.{js,jsx}'],

--- a/packages/eslint/src/shadcn.js
+++ b/packages/eslint/src/shadcn.js
@@ -1,0 +1,9 @@
+/** Shared shadcn/ui override — components export both components and variants. */
+export const shadcnConfig = [
+  {
+    files: ['src/components/ui/**/*.{js,jsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off'
+    }
+  }
+]

--- a/packages/eslint/src/vitest.js
+++ b/packages/eslint/src/vitest.js
@@ -1,6 +1,5 @@
 import globals from 'globals'
 
-/** Shared Vitest globals override — covers standard test file patterns and test utilities. */
 export const vitestConfig = [
   {
     files: [

--- a/packages/eslint/src/vitest.js
+++ b/packages/eslint/src/vitest.js
@@ -6,7 +6,7 @@ export const vitestConfig = [
     files: [
       '**/*.test.{js,jsx}',
       'src/tests/**/*.{js,jsx}',
-      'vitest.config.js'
+      '**/vitest.config.js'
     ],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/src/vitest.js
+++ b/packages/eslint/src/vitest.js
@@ -1,0 +1,21 @@
+import globals from 'globals'
+
+/** Shared Vitest globals override — covers standard test file patterns and test utilities. */
+export const vitestConfig = [
+  {
+    files: [
+      '**/*.test.{js,jsx}',
+      'src/tests/**/*.{js,jsx}',
+      'vitest.config.js'
+    ],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.vitest,
+        ...globals.node,
+        global: true
+      }
+    }
+  }
+]

--- a/packages/i18n/eslint.config.js
+++ b/packages/i18n/eslint.config.js
@@ -1,0 +1,3 @@
+import { baseConfig } from '@smela/eslint/base'
+
+export default [...baseConfig]

--- a/packages/i18n/eslint.config.js
+++ b/packages/i18n/eslint.config.js
@@ -1,3 +1,3 @@
-import { baseConfig } from '@smela/eslint/base'
+import { baseConfig } from '@smela/eslint'
 
 export default [...baseConfig]

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -7,7 +7,9 @@
     "clean": "rm -rf node_modules",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "check": "bun run format:fix",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "check": "bun run format:fix && bun run lint:fix",
     "sync": "bun scripts/sync.js",
     "sync:watch": "bun scripts/sync.js --watch"
   },
@@ -16,7 +18,9 @@
     "./resources": "./src/resources.js"
   },
   "devDependencies": {
-    "chokidar": "^5.0.0"
+    "@smela/eslint": "workspace:*",
+    "chokidar": "^5.0.0",
+    "eslint": "^9.39.2"
   },
   "peerDependencies": {
     "i18next": "^25.8.11"

--- a/smela.code-workspace
+++ b/smela.code-workspace
@@ -5,11 +5,12 @@
     { "path": "apps/web", "name": "web" },
     { "path": "packages/e2e", "name": "e2e" },
     { "path": "packages/i18n", "name": "i18n" },
+    { "path": "packages/eslint", "name": "eslint" }
   ],
   "settings": {
     "files.exclude": {
       "apps": true,
-      "packages": true,
-    },
-  },
+      "packages": true
+    }
+  }
 }


### PR DESCRIPTION
## Changes

[Feature]: Add `packages/eslint` workspace with shared flat configs (`base`, `react`, `vitest`, `playwright`, `shadcn`) all exported from a single `@smela/eslint` entry point
[Improvement]: Reduce `apps/web/eslint.config.js` from 100+ lines to ~25 by consuming shared configs
[Improvement]: Remove 7 direct ESLint plugin deps from `apps/web` — now managed centrally in `@smela/eslint`
[Feature]: Add ESLint to `packages/e2e` and `packages/i18n` for the first time via `baseConfig`
[Improvement]: Move `import/resolver` IDE metadata out of ESLint config into `apps/web/.vscode/settings.json`
[Improvement]: Remove unused `$` alias from `vite.config.js` and `jsconfig.json`
[Improvement]: Trigger web CI on `packages/eslint` changes to catch shared config regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)