### PR TITLE
Hoist typescript to root and clean up api dev deps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -54,7 +54,6 @@
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "bun-types": "^1.3.11",
     "drizzle-kit": "^0.31.10",
     "nodemailer": "^8.0.1",
     "pino-pretty": "^13.1.3",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,7 +50,7 @@
     "@faker-js/faker": "^10.3.0",
     "@react-email/preview-server": "^5.2.8",
     "@types/bun": "^1.3.11",
-    "@types/nodemailer": "^7.0.10",
+    "@types/nodemailer": "^8.0.0",
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -58,7 +58,6 @@
     "drizzle-kit": "^0.31.10",
     "nodemailer": "^8.0.1",
     "pino-pretty": "^13.1.3",
-    "react-email": "^5.2.8",
-    "typescript": "^5.9.3"
+    "react-email": "^5.2.8"
   }
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -20,7 +20,7 @@
     "allowUnreachableCode": false,
     "noPropertyAccessFromIndexSignature": true,
 
-    "types": ["bun-types"],
+    "types": ["@types/bun"],
 
     "esModuleInterop": true,
     "skipLibCheck": true

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.6",
         "prettier": "^3.8.1",
+        "typescript": "^6.0.2",
       },
     },
     "apps/api": {
@@ -35,7 +36,7 @@
         "@faker-js/faker": "^10.3.0",
         "@react-email/preview-server": "^5.2.8",
         "@types/bun": "^1.3.11",
-        "@types/nodemailer": "^7.0.10",
+        "@types/nodemailer": "^8.0.0",
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -44,7 +45,6 @@
         "nodemailer": "^8.0.1",
         "pino-pretty": "^13.1.3",
         "react-email": "^5.2.8",
-        "typescript": "^5.9.3",
       },
     },
     "apps/web": {
@@ -988,7 +988,7 @@
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@types/nodemailer": ["@types/nodemailer@7.0.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g=="],
+    "@types/nodemailer": ["@types/nodemailer@8.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
@@ -2542,7 +2542,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,6 @@
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "bun-types": "^1.3.11",
         "drizzle-kit": "^0.31.10",
         "nodemailer": "^8.0.1",
         "pino-pretty": "^13.1.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "eslint": "^10",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.1",
+    "typescript": "^6.0.2"
   },
   "scripts": {
     "clean": "bun run --parallel --filter '*' clean & rm -rf node_modules & wait",


### PR DESCRIPTION
[Improvement]: Move \`typescript\` from \`apps/api\` to root \`package.json\` so all future packages share one version
[Improvement]: Upgrade \`@types/nodemailer\` from v7 to v8 to match the installed runtime package
[Fix]: Replace duplicate \`bun-types\` with the canonical \`@types/bun\` package in api