### PR TITLE
Remove Sentry performance monitoring from web and admin

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@smela/ui": "workspace:*",
     "@smela/i18n": "workspace:*",
-    "@sentry/react": "^10.39.0",
     "@tanstack/react-query": "^5.90.21",
     "i18next": "^26.0.4",
     "i18next-http-backend": "^3.0.2",
@@ -40,7 +39,6 @@
     "@smela/eslint": "workspace:*",
     "@smela/e2e": "workspace:*",
     "@faker-js/faker": "^10.3.0",
-    "@sentry/vite-plugin": "^5.2.0",
     "@tailwindcss/vite": "^4.2.0",
     "tailwindcss": "^4.2.0",
     "@types/node": "^25.2.3",

--- a/apps/admin/src/router.jsx
+++ b/apps/admin/src/router.jsx
@@ -1,4 +1,3 @@
-import { wrapCreateBrowserRouterV6 } from '@sentry/react'
 import { AuthLayout, ErrorLayout, UserLayout } from '@smela/ui/layouts'
 import { adminActiveStatuses, Role } from '@smela/ui/lib/types'
 import {
@@ -32,9 +31,7 @@ import {
 } from '@smela/ui/routes'
 import { createBrowserRouter } from 'react-router-dom'
 
-const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter)
-
-export const router = sentryCreateBrowserRouter([
+export const router = createBrowserRouter([
   {
     element: <RootRedirect />,
     path: '/'

--- a/apps/admin/vite.config.js
+++ b/apps/admin/vite.config.js
@@ -2,15 +2,12 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { reactCompilerOptions } from '@smela/ui/react-compiler'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 import webpackStatsPlugin from 'rollup-plugin-webpack-stats'
 import { defineConfig } from 'vite'
-
-import packageJson from './package.json' with { type: 'json' }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -38,10 +35,6 @@ export default defineConfig({
       }
     }
   },
-  define: {
-    // Strip Sentry debug logging from production bundles
-    __SENTRY_DEBUG__: false
-  },
   plugins: [
     react({
       babel: {
@@ -67,18 +60,6 @@ export default defineConfig({
           modules: true,
           reasons: true,
           chunkModules: true
-        }
-      }),
-    process.env.SENTRY_AUTH_TOKEN &&
-      sentryVitePlugin({
-        org: 'smela',
-        project: `${packageJson.name}`,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        release: {
-          name: `${packageJson.name}@${packageJson.version}`
-        },
-        sourcemaps: {
-          filesToDeleteAfterUpload: ['./dist/**/*.map']
         }
       })
   ].filter(Boolean),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@smela/ui": "workspace:*",
     "@smela/i18n": "workspace:*",
-    "@sentry/react": "^10.39.0",
     "@tanstack/react-query": "^5.90.21",
     "i18next": "^26.0.4",
     "i18next-http-backend": "^3.0.2",
@@ -40,7 +39,6 @@
     "@smela/eslint": "workspace:*",
     "@smela/e2e": "workspace:*",
     "@faker-js/faker": "^10.3.0",
-    "@sentry/vite-plugin": "^5.2.0",
     "@tailwindcss/vite": "^4.2.0",
     "tailwindcss": "^4.2.0",
     "@types/node": "^25.2.3",

--- a/apps/web/src/router.jsx
+++ b/apps/web/src/router.jsx
@@ -1,4 +1,3 @@
-import { wrapCreateBrowserRouterV6 } from '@sentry/react'
 import {
   AuthLayout,
   ErrorLayout,
@@ -39,9 +38,7 @@ import {
 } from '@smela/ui/routes'
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 
-const sentryCreateBrowserRouter = wrapCreateBrowserRouterV6(createBrowserRouter)
-
-export const router = sentryCreateBrowserRouter([
+export const router = createBrowserRouter([
   {
     element: <PublicLayout />,
     errorElement: <ErrorBoundary />,

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -2,15 +2,12 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { reactCompilerOptions } from '@smela/ui/react-compiler'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 import webpackStatsPlugin from 'rollup-plugin-webpack-stats'
 import { defineConfig } from 'vite'
-
-import packageJson from './package.json' with { type: 'json' }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -31,10 +28,6 @@ export default defineConfig({
         }
       }
     }
-  },
-  define: {
-    // Strip Sentry debug logging from production bundles
-    __SENTRY_DEBUG__: false
   },
   plugins: [
     react({
@@ -61,18 +54,6 @@ export default defineConfig({
           modules: true,
           reasons: true,
           chunkModules: true
-        }
-      }),
-    process.env.SENTRY_AUTH_TOKEN &&
-      sentryVitePlugin({
-        org: 'smela',
-        project: `${packageJson.name}`,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        release: {
-          name: `${packageJson.name}@${packageJson.version}`
-        },
-        sourcemaps: {
-          filesToDeleteAfterUpload: ['./dist/**/*.map']
         }
       })
   ].filter(Boolean),

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
       "name": "@smela/admin",
       "version": "2026.3.26",
       "dependencies": {
-        "@sentry/react": "^10.39.0",
         "@smela/i18n": "workspace:*",
         "@smela/ui": "workspace:*",
         "@tanstack/react-query": "^5.90.21",
@@ -30,7 +29,6 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^10.3.0",
-        "@sentry/vite-plugin": "^5.2.0",
         "@smela/e2e": "workspace:*",
         "@smela/eslint": "workspace:*",
         "@tailwindcss/vite": "^4.2.0",
@@ -82,7 +80,6 @@
       "name": "@smela/web",
       "version": "2026.3.26",
       "dependencies": {
-        "@sentry/react": "^10.39.0",
         "@smela/i18n": "workspace:*",
         "@smela/ui": "workspace:*",
         "@tanstack/react-query": "^5.90.21",
@@ -95,7 +92,6 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^10.3.0",
-        "@sentry/vite-plugin": "^5.2.0",
         "@smela/e2e": "workspace:*",
         "@smela/eslint": "workspace:*",
         "@tailwindcss/vite": "^4.2.0",
@@ -826,31 +822,9 @@
 
     "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.45.0", "", { "dependencies": { "@sentry-internal/replay": "10.45.0", "@sentry/core": "10.45.0" } }, "sha512-nvq/AocdZTuD7y0KSiWi3gVaY0s5HOFy86mC/v1kDZmT/jsBAzN5LDkk/f1FvsWma1peqQmpUqxvhC+YIW294Q=="],
 
-    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.2.0", "", {}, "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg=="],
-
     "@sentry/browser": ["@sentry/browser@10.45.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.45.0", "@sentry-internal/feedback": "10.45.0", "@sentry-internal/replay": "10.45.0", "@sentry-internal/replay-canvas": "10.45.0", "@sentry/core": "10.45.0" } }, "sha512-e/a8UMiQhqqv706McSIcG6XK+AoQf9INthi2pD+giZfNRTzXTdqHzUT5OIO5hg8Am6eF63nDJc+vrYNPhzs51Q=="],
 
     "@sentry/bun": ["@sentry/bun@10.45.0", "", { "dependencies": { "@sentry/core": "10.45.0", "@sentry/node": "10.45.0" } }, "sha512-f9+24fp1Ew09qcqQ2DMKo0Dh/4WIE8G4D3/CLh8pgdwjP8A+5cvTQLcdUsqZll361P4jmXS+ZEi5KlmPv/ddGw=="],
-
-    "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.2.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.2.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w=="],
-
-    "@sentry/cli": ["@sentry/cli@2.58.5", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.5", "@sentry/cli-linux-arm": "2.58.5", "@sentry/cli-linux-arm64": "2.58.5", "@sentry/cli-linux-i686": "2.58.5", "@sentry/cli-linux-x64": "2.58.5", "@sentry/cli-win32-arm64": "2.58.5", "@sentry/cli-win32-i686": "2.58.5", "@sentry/cli-win32-x64": "2.58.5" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg=="],
-
-    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.5", "", { "os": "darwin" }, "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ=="],
-
-    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw=="],
-
-    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ=="],
-
-    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw=="],
-
-    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g=="],
-
-    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA=="],
-
-    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g=="],
-
-    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.5", "", { "os": "win32", "cpu": "x64" }, "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg=="],
 
     "@sentry/core": ["@sentry/core@10.45.0", "", {}, "sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q=="],
 
@@ -861,10 +835,6 @@
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.45.0", "", { "dependencies": { "@sentry/core": "10.45.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-PmuGO+p/gC3ZQ8ddOeJ5P9ApnTTm35i12Bpuyb13AckCbNSJFvG2ggZda35JQOmiFU0kKYiwkoFAa8Mvj9od3Q=="],
 
     "@sentry/react": ["@sentry/react@10.45.0", "", { "dependencies": { "@sentry/browser": "10.45.0", "@sentry/core": "10.45.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-jLezuxi4BUIU3raKyAPR5xMbQG/nhwnWmKo5p11NCbLmWzkS+lxoyDTUB4B8TAKZLfdtdkKLOn1S0tFc8vbUHw=="],
-
-    "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.2.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.0", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-a8LfpvcYMFtFSroro5MpCcOoS528LeLfUHzxWURnpofOnY+Aso9Si4y4dFlna+RKqxCXjmFbn6CLnfI+YrHysQ=="],
-
-    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.2.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.0", "@sentry/rollup-plugin": "5.2.0" } }, "sha512-4Jo3ixBspso5HY81PDvZdRXkH9wYGVmcw/0a2IX9ejbyKBdHqkYg4IhAtNqGUAyGuHwwRS9Y1S+sCMvrXv6htw=="],
 
     "@sindresorhus/base62": ["@sindresorhus/base62@1.0.0", "", {}, "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA=="],
 
@@ -2232,8 +2202,6 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
-    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
-
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
@@ -2776,12 +2744,6 @@
 
     "@react-email/tailwind/tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
-    "@sentry/bundler-plugin-core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
-
-    "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
-    "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
     "@storybook/react-vite/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "@stylistic/eslint-plugin/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
@@ -3166,10 +3128,6 @@
 
     "@react-email/preview-server/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
-    "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
-
-    "@sentry/cli/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
-
     "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.58.1", "", {}, "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw=="],
 
     "@typescript-eslint/rule-tester/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.1", "", { "dependencies": { "@typescript-eslint/types": "8.57.1", "@typescript-eslint/visitor-keys": "8.57.1" } }, "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg=="],
@@ -3351,10 +3309,6 @@
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "@sentry/cli/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "@sentry/cli/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 


### PR DESCRIPTION
## Summary

[Performance]: Remove Sentry performance monitoring packages and router wrappers from both frontend apps
[Improvement]: Simplify build configuration by removing unused Sentry vite plugins
[Improvement]: Replace Sentry router wrappers with standard React Router createBrowserRouter
[Fix]: Clean up package dependencies to reduce bundle size and eliminate unused performance tracking

This change removes Sentry's performance monitoring features while keeping error tracking via the UI package abstraction. The apps now use standard React Router without performance overhead.

## Changes
- Removed `@sentry/react` and `@sentry/vite-plugin` from both web and admin apps
- Replaced `wrapCreateBrowserRouterV6` with standard `createBrowserRouter`
- Cleaned up Vite configs by removing Sentry plugins and debug flags
- Error tracking still works through `@smela/ui/services` abstraction