### PR TITLE
Add Alert stories and AlertHeader primitive

### DIFF
--- a/packages/ui/src/components/Alert/Alert.jsx
+++ b/packages/ui/src/components/Alert/Alert.jsx
@@ -7,8 +7,14 @@ import { AlertCircle } from 'lucide-react'
 
 export const Alert = ({ variant, title, description }) => (
   <AlertRoot variant={variant}>
-    <AlertCircle className='size-4' />
-    <AlertTitle>{title}</AlertTitle>
-    {description && <AlertDescription>{description}</AlertDescription>}
+    <div className='flex flex-col gap-1'>
+      <div className='flex items-center gap-2'>
+        <AlertCircle className='size-4 shrink-0' />
+        <AlertTitle>{title}</AlertTitle>
+      </div>
+      {description && (
+        <AlertDescription className='pl-6'>{description}</AlertDescription>
+      )}
+    </div>
   </AlertRoot>
 )

--- a/packages/ui/src/components/Alert/Alert.jsx
+++ b/packages/ui/src/components/Alert/Alert.jsx
@@ -1,20 +1,19 @@
 import {
   Alert as AlertRoot,
   AlertDescription,
+  AlertHeader,
   AlertTitle
 } from '@ui/components/ui'
 import { AlertCircle } from 'lucide-react'
 
 export const Alert = ({ variant, title, description }) => (
   <AlertRoot variant={variant}>
-    <div className='flex flex-col gap-1'>
-      <div className='flex items-center gap-2'>
-        <AlertCircle className='size-4 shrink-0' />
-        <AlertTitle>{title}</AlertTitle>
-      </div>
-      {description && (
-        <AlertDescription className='pl-6'>{description}</AlertDescription>
-      )}
-    </div>
+    <AlertHeader>
+      <AlertCircle className='size-4 shrink-0' />
+      <AlertTitle>{title}</AlertTitle>
+    </AlertHeader>
+    {description && (
+      <AlertDescription className='pl-6'>{description}</AlertDescription>
+    )}
   </AlertRoot>
 )

--- a/packages/ui/src/components/Alert/Alert.stories.jsx
+++ b/packages/ui/src/components/Alert/Alert.stories.jsx
@@ -1,7 +1,7 @@
 import { Alert } from '.'
 
 const withContainer = Story => (
-  <div className='flex min-h-screen w-full items-center justify-center'>
+  <div className='flex items-center'>
     <Story />
   </div>
 )
@@ -10,7 +10,7 @@ export default {
   title: 'Components/Alert',
   component: Alert,
   decorators: [withContainer],
-  parameters: { layout: 'padded' },
+  parameters: { layout: 'centered' },
   argTypes: {
     variant: {
       control: 'select',

--- a/packages/ui/src/components/Alert/Alert.stories.jsx
+++ b/packages/ui/src/components/Alert/Alert.stories.jsx
@@ -1,0 +1,45 @@
+import { Alert } from '.'
+
+const withContainer = Story => (
+  <div className='flex min-h-screen w-full items-center justify-center'>
+    <Story />
+  </div>
+)
+
+export default {
+  title: 'Components/Alert',
+  component: Alert,
+  decorators: [withContainer],
+  parameters: { layout: 'padded' },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive']
+    },
+    title: { control: 'text' },
+    description: { control: 'text' }
+  },
+  args: {
+    variant: 'default',
+    title: 'Your session has expired',
+    description: 'Please log in again to continue.'
+  }
+}
+
+export const Default = {}
+
+export const Destructive = {
+  args: {
+    variant: 'destructive',
+    title: 'Delete your account',
+    description:
+      'This action is permanent and cannot be undone. All your data will be lost.'
+  }
+}
+
+export const TitleOnly = {
+  args: {
+    title: 'No description provided',
+    description: undefined
+  }
+}

--- a/packages/ui/src/components/ui/alert.jsx
+++ b/packages/ui/src/components/ui/alert.jsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority'
 import * as React from 'react'
 
 const alertVariants = cva(
-  "group/alert relative flex w-full items-center gap-2.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 *:[svg]:shrink-0 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  "group/alert relative flex flex-col items-start gap-1 w-full rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 *:[svg]:shrink-0 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -24,6 +24,16 @@ function Alert({ className, variant, ...props }) {
       data-slot='alert'
       role='alert'
       className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertHeader({ className, ...props }) {
+  return (
+    <div
+      data-slot='alert-header'
+      className={cn('flex items-center gap-2', className)}
       {...props}
     />
   )
@@ -65,4 +75,4 @@ function AlertAction({ className, ...props }) {
   )
 }
 
-export { Alert, AlertAction, AlertDescription, AlertTitle }
+export { Alert, AlertAction, AlertDescription, AlertHeader, AlertTitle }

--- a/packages/ui/src/components/ui/index.js
+++ b/packages/ui/src/components/ui/index.js
@@ -4,7 +4,13 @@ export {
   AccordionItem,
   AccordionTrigger
 } from './accordion'
-export { Alert, AlertDescription, AlertTitle } from './alert'
+export {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertHeader,
+  AlertTitle
+} from './alert'
 export { Avatar, AvatarFallback, AvatarImage, AvatarStatus } from './avatar'
 export { Badge } from './badge'
 export { Button } from './button'


### PR DESCRIPTION
[Feature]: Add Storybook stories for Alert component with Default, Destructive, and TitleOnly variants
[Feature]: Extract AlertHeader as a reusable primitive in the shadcn alert primitive
[Improvement]: Update alertVariants base styles to use flex-col layout by default
[Improvement]: Export AlertAction and AlertHeader from @ui/components/ui index