### PR TITLE
Add and refactor Storybook stories for UI components

### DIFF
--- a/packages/ui/.storybook/preview.jsx
+++ b/packages/ui/.storybook/preview.jsx
@@ -20,8 +20,10 @@ i18next.use(initReactI18next).init({
   interpolation: { escapeValue: false }
 })
 
-// Register mocks for auth hooks
+// Register mocks for hooks used in stories
 sb.mock('../src/hooks/useAuth.js')
+sb.mock('../src/hooks/useOwner.js')
+sb.mock('../src/hooks/useTeam.js')
 
 /** @type { import('@storybook/react-vite').Preview } */
 const preview = {

--- a/packages/ui/src/components/Copyright/Copyright.stories.jsx
+++ b/packages/ui/src/components/Copyright/Copyright.stories.jsx
@@ -10,10 +10,10 @@ const sizeToClass = {
 export default {
   title: 'Components/Copyright',
   component: Copyright,
-  parameters: { layout: 'fullscreen' },
+  parameters: { layout: 'centered' },
   decorators: [
     Story => (
-      <div className='flex items-center justify-center w-full min-h-screen'>
+      <div className='flex items-center'>
         <Story />
       </div>
     )

--- a/packages/ui/src/components/badges/badges.stories.jsx
+++ b/packages/ui/src/components/badges/badges.stories.jsx
@@ -8,19 +8,19 @@ const MINUTE = 60
 const HOUR = 60 * MINUTE
 const DAY = 24 * HOUR
 
+const withContainer = Story => (
+  <div className='flex items-center p-6'>
+    <Story />
+  </div>
+)
+
 export default {
   title: 'Components/Badges',
+  decorators: [withContainer],
   parameters: { layout: 'centered' }
 }
 
 export const LastActive = {
-  decorators: [
-    Story => (
-      <div className='flex items-center justify-center p-6'>
-        <Story />
-      </div>
-    )
-  ],
   render: () => (
     <table className='border-separate border-spacing-y-2 text-sm'>
       <tbody>
@@ -67,13 +67,6 @@ export const Team = {
 }
 
 export const You = {
-  decorators: [
-    Story => (
-      <div className='flex items-center justify-center p-6'>
-        <Story />
-      </div>
-    )
-  ],
   render: () => (
     <div className='flex flex-col items-center gap-4'>
       <div className='flex items-center gap-1 text-sm'>

--- a/packages/ui/src/components/buttons/buttons.stories.jsx
+++ b/packages/ui/src/components/buttons/buttons.stories.jsx
@@ -1,0 +1,45 @@
+import { AddButton } from './AddButton'
+import { BackButton } from './BackButton'
+import { InviteButton } from './InviteButton'
+
+const withContainer = Story => (
+  <div className='flex items-center gap-4 p-6'>
+    <Story />
+  </div>
+)
+
+export default {
+  title: 'Components/Buttons',
+  decorators: [withContainer],
+  parameters: { layout: 'centered' }
+}
+
+export const Add = {
+  render: () => (
+    <>
+      <AddButton label='Add Member' onClick={() => {}} />
+      <AddButton
+        label='Add Admin'
+        onClick={() => {}}
+        hideTextOnMobile={false}
+      />
+    </>
+  )
+}
+
+export const Invite = {
+  render: () => (
+    <>
+      <InviteButton label='Invite Member' onClick={() => {}} />
+      <InviteButton
+        label='Invite Admin'
+        onClick={() => {}}
+        hideTextOnMobile={false}
+      />
+    </>
+  )
+}
+
+export const Back = {
+  render: () => <BackButton />
+}

--- a/packages/ui/src/components/dialogs/dialogs.stories.jsx
+++ b/packages/ui/src/components/dialogs/dialogs.stories.jsx
@@ -1,15 +1,22 @@
 import { Dialog, dialogContentVariants } from '@ui/components/ui/dialog'
+import { useAdminDefaultPermissions } from '@ui/hooks/useOwner'
+import { useTeamMemberDefaultPermissions } from '@ui/hooks/useTeam'
 
-import { PricingSliderDialog, RemoveTeamMemberDialog } from '.'
+import {
+  CreateAdminDialog,
+  CreateMemberDialog,
+  CreateTeamDialog,
+  PricingSliderDialog,
+  RemoveTeamMemberDialog
+} from '.'
 
-// Wrapper with Dialog context for Base UI components
+const noop = () => {}
+
 const DialogWrapper = ({ size, children }) => (
   <Dialog open>
     <div className={dialogContentVariants({ size })}>{children}</div>
   </Dialog>
 )
-
-const noop = () => {}
 
 export default {
   title: 'Components/Dialogs',
@@ -32,6 +39,51 @@ export const RemoveTeamMember = {
         onClose={noop}
         onConfirm={noop}
       />
+    </DialogWrapper>
+  )
+}
+
+export const CreateTeam = {
+  args: { size: 'sm' },
+  render: ({ size }) => (
+    <DialogWrapper size={size}>
+      <CreateTeamDialog onClose={noop} onSubmit={noop} />
+    </DialogWrapper>
+  )
+}
+
+export const CreateMember = {
+  args: { size: 'md' },
+  beforeEach: () => {
+    useTeamMemberDefaultPermissions.mockReturnValue({
+      data: {
+        users: { view: true, manage: false },
+        teams: { view: true, manage: false }
+      },
+      isPending: false
+    })
+  },
+  render: ({ size }) => (
+    <DialogWrapper size={size}>
+      <CreateMemberDialog teamId='team_123' onClose={noop} onSubmit={noop} />
+    </DialogWrapper>
+  )
+}
+
+export const CreateAdmin = {
+  args: { size: 'md' },
+  beforeEach: () => {
+    useAdminDefaultPermissions.mockReturnValue({
+      data: {
+        users: { view: true, manage: true },
+        teams: { view: true, manage: true }
+      },
+      isPending: false
+    })
+  },
+  render: ({ size }) => (
+    <DialogWrapper size={size}>
+      <CreateAdminDialog onClose={noop} onSubmit={noop} />
     </DialogWrapper>
   )
 }


### PR DESCRIPTION
## Summary

[Feature]: Add `buttons.stories.jsx` covering `AddButton`, `InviteButton`, and `BackButton` with `hideTextOnMobile` variants
[Feature]: Add `CreateTeam`, `CreateMember`, and `CreateAdmin` stories to dialogs with realistic permission mocks
[Improvement]: Lift shared decorator to default export in `badges.stories.jsx`, eliminating per-story duplication
[Improvement]: Register `useOwner` and `useTeam` hook mocks globally in `preview.jsx` so dialog stories can call `mockReturnValue`
[Fix]: Align `Copyright.stories.jsx` layout and decorator with the established pattern used across other story files

## Test plan

- [ ] Open Storybook and verify all new stories render without errors
- [ ] Confirm `CreateAdmin` shows `view` and `manage` both enabled
- [ ] Confirm `CreateMember` shows `view` enabled, `manage` disabled
- [ ] Confirm `AddButton` and `InviteButton` show label-hidden and label-visible variants
- [ ] Confirm `BackButton` renders translated "back" text and ghost button style

🤖 Generated with [Claude Code](https://claude.com/claude-code)