### PR TITLE
Rename delete to remove for team member actions

### DIFF
--- a/apps/web/e2e/user-invite.spec.js
+++ b/apps/web/e2e/user-invite.spec.js
@@ -242,7 +242,7 @@ test.describe.serial('User: Team Members', () => {
 
     await ownRow.click({ button: 'right' })
     await expect(
-      page.getByRole('menuitem', { name: t.contextMenu.delete })
+      page.getByRole('menuitem', { name: t.contextMenu.remove })
     ).not.toBeVisible()
 
     // Close context menu
@@ -255,7 +255,7 @@ test.describe.serial('User: Team Members', () => {
 
     await otherRow.click({ button: 'right' })
     await expect(
-      page.getByRole('menuitem', { name: t.contextMenu.delete })
+      page.getByRole('menuitem', { name: t.contextMenu.remove })
     ).toBeVisible()
 
     await page.keyboard.press('Escape')
@@ -287,7 +287,7 @@ test.describe.serial('User: Team Members', () => {
 
     await memberRow.click({ button: 'right' })
     await expect(
-      page.getByRole('menuitem', { name: t.contextMenu.delete })
+      page.getByRole('menuitem', { name: t.contextMenu.remove })
     ).toBeVisible()
 
     const deletePath = TEAM_MEMBER_PATH.replace(':teamId', teamId).replace(
@@ -300,7 +300,7 @@ test.describe.serial('User: Team Members', () => {
       { path: membersPath, method: 'GET', status: HttpStatus.OK }
     ])
 
-    await page.getByRole('menuitem', { name: t.contextMenu.delete }).click()
+    await page.getByRole('menuitem', { name: t.contextMenu.remove }).click()
 
     // Confirm in the dialog
     await page.getByRole('button', { name: t.team.members.remove.cta }).click()

--- a/packages/eslint/src/base.js
+++ b/packages/eslint/src/base.js
@@ -44,6 +44,16 @@ export const basePlugins = {
 
 export const baseConfig = [
   {
+    ignores: [
+      '**/dist/**',
+      '**/build/**',
+      '**/.vite/**',
+      '**/coverage/**',
+      '**/html-report/**',
+      '**/*.min.js'
+    ]
+  },
+  {
     files: ['**/*.js'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/packages/eslint/src/base.js
+++ b/packages/eslint/src/base.js
@@ -42,16 +42,18 @@ export const basePlugins = {
   'simple-import-sort': simpleImportSort
 }
 
+export const globalIgnores = [
+  '**/dist/**',
+  '**/build/**',
+  '**/.vite/**',
+  '**/coverage/**',
+  '**/html-report/**',
+  '**/*.min.js'
+]
+
 export const baseConfig = [
   {
-    ignores: [
-      '**/dist/**',
-      '**/build/**',
-      '**/.vite/**',
-      '**/coverage/**',
-      '**/html-report/**',
-      '**/*.min.js'
-    ]
+    ignores: globalIgnores
   },
   {
     files: ['**/*.js'],

--- a/packages/eslint/src/index.js
+++ b/packages/eslint/src/index.js
@@ -1,4 +1,4 @@
-export { baseConfig, basePlugins, baseRules } from './base.js'
+export { baseConfig, basePlugins, baseRules, globalIgnores } from './base.js'
 export { playwrightConfig } from './playwright.js'
 export { reactConfig } from './react.js'
 export { shadcnConfig } from './shadcn.js'

--- a/packages/eslint/src/react.js
+++ b/packages/eslint/src/react.js
@@ -4,18 +4,11 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import globals from 'globals'
 
-import { basePlugins, baseRules } from './base.js'
+import { basePlugins, baseRules, globalIgnores } from './base.js'
 
 export const reactConfig = [
   {
-    ignores: [
-      '**/dist/**',
-      '**/build/**',
-      '**/.vite/**',
-      '**/coverage/**',
-      '**/html-report/**',
-      '**/*.min.js'
-    ]
+    ignores: globalIgnores
   },
   {
     files: ['**/*.{js,jsx}'],

--- a/packages/eslint/src/react.js
+++ b/packages/eslint/src/react.js
@@ -7,7 +7,16 @@ import globals from 'globals'
 import { basePlugins, baseRules } from './base.js'
 
 export const reactConfig = [
-  { ignores: ['dist', 'build', 'coverage'] },
+  {
+    ignores: [
+      '**/dist/**',
+      '**/build/**',
+      '**/.vite/**',
+      '**/coverage/**',
+      '**/html-report/**',
+      '**/*.min.js'
+    ]
+  },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {

--- a/packages/i18n/src/resources/en.json
+++ b/packages/i18n/src/resources/en.json
@@ -37,9 +37,9 @@
   "changesSaved": "Changes saved successfully.",
   "contextMenu": {
     "cancel": "Cancel",
-    "delete": "Delete",
     "invite": "Invitation",
     "open": "Open",
+    "remove": "Remove",
     "resend": "Resend"
   },
   "continueWithGoogle": "Continue with Google",

--- a/packages/i18n/src/resources/uk.json
+++ b/packages/i18n/src/resources/uk.json
@@ -37,9 +37,9 @@
   "changesSaved": "Зміни успішно збережено.",
   "contextMenu": {
     "cancel": "Скасувати",
-    "delete": "Видалити",
     "invite": "Запрошення",
     "open": "Відкрити",
+    "remove": "Видалити",
     "resend": "Надіслати повторно"
   },
   "continueWithGoogle": "Продовжити з Google",

--- a/packages/ui/src/components/profile/RemoveMemberItem.jsx
+++ b/packages/ui/src/components/profile/RemoveMemberItem.jsx
@@ -5,12 +5,12 @@ import {
   ItemContent,
   ItemTitle
 } from '@ui/components/ui'
-import { useDeleteTeamMember } from '@ui/hooks/useDeleteTeamMember'
 import { useLocale } from '@ui/hooks/useLocale'
+import { useRemoveTeamMember } from '@ui/hooks/useRemoveTeamMember'
 
 export const RemoveMemberItem = ({ member, teamId }) => {
   const { t } = useLocale()
-  const { handleDeleteMember } = useDeleteTeamMember(teamId)
+  const { handleRemoveMember } = useRemoveTeamMember(teamId)
 
   return (
     <Item variant='outline' className='border-destructive/20'>
@@ -22,7 +22,7 @@ export const RemoveMemberItem = ({ member, teamId }) => {
       <ItemActions>
         <Button
           variant='destructive'
-          onClick={() => handleDeleteMember(member)}
+          onClick={() => handleRemoveMember(member)}
         >
           {t('team.members.remove.cta')}
         </Button>

--- a/packages/ui/src/components/table/contextMenuItems.js
+++ b/packages/ui/src/components/table/contextMenuItems.js
@@ -31,13 +31,13 @@ export const createInviteItem = (
   ]
 })
 
-export const createDeleteMemberItem = (
+export const createRemoveMemberItem = (
   t,
-  { handleDeleteMember, isDeleting, meId }
+  { handleRemoveMember, isDeleting, meId }
 ) => ({
   icon: UserMinus,
-  label: t('contextMenu.delete'),
-  onClick: handleDeleteMember,
+  label: t('contextMenu.remove'),
+  onClick: handleRemoveMember,
   variant: 'destructive',
   disabled: isDeleting,
   isVisible: member => member.id !== meId

--- a/packages/ui/src/components/team/TeamMembersSection/TeamMembersSection.jsx
+++ b/packages/ui/src/components/team/TeamMembersSection/TeamMembersSection.jsx
@@ -4,14 +4,14 @@ import { Spinner } from '@ui/components/Spinner'
 import { EmptyState, ErrorState } from '@ui/components/states'
 import { ColumnVisibilityDropdown, Table } from '@ui/components/table'
 import {
-  createDeleteMemberItem,
   createInviteItem,
-  createOpenItem
+  createOpenItem,
+  createRemoveMemberItem
 } from '@ui/components/table/contextMenuItems'
 import { useCurrentUser } from '@ui/hooks/useAuth'
 import { useColumnVisibility } from '@ui/hooks/useColumnVisibility'
-import { useDeleteTeamMember } from '@ui/hooks/useDeleteTeamMember'
 import { useLocale } from '@ui/hooks/useLocale'
+import { useRemoveTeamMember } from '@ui/hooks/useRemoveTeamMember'
 import { useTeamMembers } from '@ui/hooks/useTeam'
 
 import { getColumns } from './columns'
@@ -48,7 +48,7 @@ export const TeamMembersSection = ({
     handleCancelInvite,
     isCancelling
   } = useInvite(teamId)
-  const { handleDeleteMember, isDeleting } = useDeleteTeamMember(teamId)
+  const { handleRemoveMember, isDeleting } = useRemoveTeamMember(teamId)
 
   const openMemberProfile = onRowClick
 
@@ -60,7 +60,7 @@ export const TeamMembersSection = ({
       handleCancelInvite,
       isCancelling
     }),
-    createDeleteMemberItem(t, { handleDeleteMember, isDeleting, meId: me?.id })
+    createRemoveMemberItem(t, { handleRemoveMember, isDeleting, meId: me?.id })
   ]
 
   const columns = getColumns(t, formatDate, me?.id)

--- a/packages/ui/src/hooks/useRemoveTeamMember.jsx
+++ b/packages/ui/src/hooks/useRemoveTeamMember.jsx
@@ -1,17 +1,17 @@
 import { RemoveTeamMemberDialog } from '@ui/components/dialogs'
 import { useLocale } from '@ui/hooks/useLocale'
 import { useModal } from '@ui/hooks/useModal'
-import { useDeleteMember } from '@ui/hooks/useTeam'
+import { useRemoveMember } from '@ui/hooks/useTeam'
 import { useToast } from '@ui/hooks/useToast'
 
-export const useDeleteTeamMember = teamId => {
+export const useRemoveTeamMember = teamId => {
   const { t, te } = useLocale()
   const { openModal } = useModal()
   const { showSuccessToast, showErrorToast } = useToast()
-  const { mutate: deleteMember, isPending: isDeleting } =
-    useDeleteMember(teamId)
+  const { mutate: removeMember, isPending: isDeleting } =
+    useRemoveMember(teamId)
 
-  const handleDeleteMember = member => {
+  const handleRemoveMember = member => {
     const close = openModal({
       children: (
         <RemoveTeamMemberDialog
@@ -19,7 +19,7 @@ export const useDeleteTeamMember = teamId => {
           onClose={() => close()}
           onConfirm={() => {
             close()
-            deleteMember(member.id, {
+            removeMember(member.id, {
               onSuccess: () => {
                 showSuccessToast(t('team.members.remove.success'))
               },
@@ -33,5 +33,5 @@ export const useDeleteTeamMember = teamId => {
     })
   }
 
-  return { handleDeleteMember, isDeleting }
+  return { handleRemoveMember, isDeleting }
 }

--- a/packages/ui/src/hooks/useTeam.js
+++ b/packages/ui/src/hooks/useTeam.js
@@ -246,7 +246,7 @@ export const useCancelMemberInvite = teamId => {
   })
 }
 
-export const useDeleteMember = teamId => {
+export const useRemoveMember = teamId => {
   const queryClient = useQueryClient()
 
   return useMutation({


### PR DESCRIPTION
[Improvement]: Rename `contextMenu.delete` → `contextMenu.remove` in translations for semantic accuracy — removing a member from a team is not destructive deletion
[Improvement]: Rename `createDeleteMemberItem` → `createRemoveMemberItem`, `useDeleteTeamMember` → `useRemoveTeamMember`, and related identifiers throughout for consistency
[Fix]: Update E2E tests in `user-invite.spec.js` to reference `contextMenu.remove` instead of stale `contextMenu.delete` key
[Improvement]: Add global ESLint ignores for `dist`, `build`, `.vite`, `coverage`, `html-report`, and `*.min.js` to prevent linting generated/vendor files
[Improvement]: Extract shared `globalIgnores` constant in `packages/eslint/src/base.js`, reuse in `reactConfig`, and export from index — eliminates duplication