### PR TITLE
Fix check-invite error code for invalid state

### DIFF
--- a/apps/api/src/use-cases/auth/__tests__/check-invite.test.ts
+++ b/apps/api/src/use-cases/auth/__tests__/check-invite.test.ts
@@ -219,7 +219,7 @@ describe('Check Invite', () => {
   })
 
   describe('when user has no team membership and no admin role', () => {
-    it('should throw InternalError', async () => {
+    it('should throw TokenDeprecated', async () => {
       mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
       mockRbacRepo.findRole.mockResolvedValue(undefined)
 
@@ -228,8 +228,8 @@ describe('Check Invite', () => {
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).code).toBe(ErrorCode.InternalError)
-        expect((error as AppError).message).toBe('Invalid invitation state')
+        expect((error as AppError).code).toBe(ErrorCode.TokenDeprecated)
+        expect((error as AppError).message).toBe('Invalid invite')
       }
 
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(
@@ -240,7 +240,7 @@ describe('Check Invite', () => {
   })
 
   describe('when user has non-admin role', () => {
-    it('should throw InternalError', async () => {
+    it('should throw TokenDeprecated', async () => {
       mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
       mockRbacRepo.findRole.mockResolvedValue({
         ...mockAdminRole,
@@ -252,8 +252,8 @@ describe('Check Invite', () => {
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeInstanceOf(AppError)
-        expect((error as AppError).code).toBe(ErrorCode.InternalError)
-        expect((error as AppError).message).toBe('Invalid invitation state')
+        expect((error as AppError).code).toBe(ErrorCode.TokenDeprecated)
+        expect((error as AppError).message).toBe('Invalid invite')
       }
     })
   })

--- a/apps/api/src/use-cases/auth/check-invite.ts
+++ b/apps/api/src/use-cases/auth/check-invite.ts
@@ -54,5 +54,5 @@ export const checkInvite = async (
     return adminInvite
   }
 
-  throw new AppError(ErrorCode.InternalError, 'Invalid invitation state')
+  throw new AppError(ErrorCode.TokenDeprecated, 'Invalid invite')
 }

--- a/apps/web/e2e/user-invite.spec.js
+++ b/apps/web/e2e/user-invite.spec.js
@@ -4,6 +4,7 @@ import { waitForApiCall, waitForApiCalls } from '@smela/e2e/api'
 import { generateEmailAddress } from '@smela/e2e/email'
 import { HttpStatus } from '@smela/ui/lib/net'
 import {
+  CHECK_INVITE_PATH,
   TEAM_MEMBER_CANCEL_INVITE_PATH,
   TEAM_MEMBER_PATH,
   TEAM_MEMBERS_DEFAULT_PERMISSIONS_PATH,
@@ -312,5 +313,25 @@ test.describe.serial('User: Team Members', () => {
     await expect(memberRow).not.toBeVisible()
 
     await logOut(page, t)
+  })
+
+  test('rejects cancelled invite link and redirects to login', async ({
+    page,
+    t,
+    emailService
+  }) => {
+    const { link } = await emailService.waitForInvitationEmail(newMember.email)
+
+    const checkInvitePromise = waitForApiCall(page, {
+      path: CHECK_INVITE_PATH,
+      method: 'GET',
+      status: HttpStatus.GONE
+    })
+
+    await page.goto(link)
+    await checkInvitePromise
+
+    await expect(page).toHaveURL('/login')
+    await expect(page.getByText(t.backend['token/deprecated'])).toBeVisible()
   })
 })


### PR DESCRIPTION
[Fix]: Return \`token/deprecated\` (410) instead of \`InternalError\` when invited user has no team membership or non-admin role, matching the expected error contract for cancelled/removed invites

[Fix]: Update stale unit tests for \`check-invite\` use case to assert \`TokenDeprecated\` error code and correct message

[Feature]: Add E2E test verifying that a cancelled invite link is rejected with a 410 and redirects to login