### PR TITLE
Split FE_BASE_URL into FE_USER_URL and FE_ADMIN_URL

### DIFF
--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -160,11 +160,7 @@ test.describe.serial('Owner: Admin Invitation', () => {
   }) => {
     const { link } = await emailService.waitForInvitationEmail(newAdmin.email)
 
-    expect(link).toContain('/accept-invite?token=')
-
-    const url = new URL(link)
-
-    await page.goto(url.pathname + url.search)
+    await page.goto(link)
 
     // Verify page title
     await expect(

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,7 +20,8 @@ COOKIE_REFRESH_TOKEN_EXPIRATION=86400 # 24 hours
 COOKIE_REFRESH_TOKEN_DOMAIN=localhost # required for staging/production
 ALLOWED_ORIGINS=http://localhost:5173 # required for staging/production
 BE_BASE_URL=http://localhost:3000
-FE_BASE_URL=http://localhost:5173
+FE_USER_URL=http://localhost:5173
+FE_ADMIN_URL=http://localhost:5175
 
 # Email
 # Resend has highest priority - if API key is provided, it will be used

--- a/apps/api/src/env/__tests__/env.test.ts
+++ b/apps/api/src/env/__tests__/env.test.ts
@@ -62,7 +62,8 @@ describe('Environment Configuration', () => {
     expect(devEnv.COOKIE_REFRESH_TOKEN_NAME).toBe('refresh-token')
     expect(devEnv.COOKIE_REFRESH_TOKEN_EXPIRATION).toBe(86400)
     expect(devEnv.BE_BASE_URL).toBe('http://localhost:3000')
-    expect(devEnv.FE_BASE_URL).toBe('http://localhost:5173')
+    expect(devEnv.FE_USER_URL).toBe('http://localhost:5173')
+    expect(devEnv.FE_ADMIN_URL).toBe('http://localhost:5175')
 
     // Company defaults
     expect(devEnv.COMPANY_NAME).toBe('SMELA')

--- a/apps/api/src/env/network.ts
+++ b/apps/api/src/env/network.ts
@@ -38,6 +38,7 @@ export const networkEnvVars = (nodeEnv?: string) => {
 
     // Base URLs
     BE_BASE_URL: z.url().default('http://localhost:3000'),
-    FE_BASE_URL: z.url().default('http://localhost:5173')
+    FE_USER_URL: z.url().default('http://localhost:5173'),
+    FE_ADMIN_URL: z.url().default('http://localhost:5175')
   }
 }

--- a/apps/api/src/services/email/email-agent.ts
+++ b/apps/api/src/services/email/email-agent.ts
@@ -70,12 +70,13 @@ export class EmailAgent {
   async sendUserInvitationEmail(
     firstName: string,
     email: string,
+    role: Role,
     token: string,
     inviterName?: string,
     teamName?: string,
     preferences?: UserPreferences
   ) {
-    const inviteUrl = `${env.FE_USER_URL}/accept-invite?token=${token}`
+    const inviteUrl = `${getFeBaseUrl(role)}/accept-invite?token=${token}`
 
     await this.service.send(
       EmailType.USER_INVITATION,

--- a/apps/api/src/services/email/email-agent.ts
+++ b/apps/api/src/services/email/email-agent.ts
@@ -1,11 +1,15 @@
-import type { UserPreferences } from '@/types'
+import type { Role, UserPreferences } from '@/types'
 
 import env from '@/env'
+import { isAdmin } from '@/types'
 
 import { EmailType } from './email-type'
 import { createEmailProvider } from './providers'
 import { buildEmailRegistry } from './registry'
 import { EmailService } from './service'
+
+const getFeBaseUrl = (role: Role) =>
+  isAdmin(role) ? env.FE_ADMIN_URL : env.FE_USER_URL
 
 export class EmailAgent {
   private static instance: EmailAgent | null = null
@@ -30,7 +34,7 @@ export class EmailAgent {
     token: string,
     preferences?: UserPreferences
   ) {
-    const verificationUrl = `${env.FE_BASE_URL}/verify-email?token=${token}`
+    const verificationUrl = `${env.FE_USER_URL}/verify-email?token=${token}`
 
     await this.service.send(
       EmailType.EMAIL_VERIFICATION,
@@ -46,10 +50,11 @@ export class EmailAgent {
   async sendResetPasswordEmail(
     firstName: string,
     email: string,
+    role: Role,
     token: string,
     preferences?: UserPreferences
   ) {
-    const resetUrl = `${env.FE_BASE_URL}/reset-password?token=${token}`
+    const resetUrl = `${getFeBaseUrl(role)}/reset-password?token=${token}`
 
     await this.service.send(
       EmailType.PASSWORD_RESET,
@@ -70,7 +75,7 @@ export class EmailAgent {
     teamName?: string,
     preferences?: UserPreferences
   ) {
-    const inviteUrl = `${env.FE_BASE_URL}/accept-invite?token=${token}`
+    const inviteUrl = `${env.FE_USER_URL}/accept-invite?token=${token}`
 
     await this.service.send(
       EmailType.USER_INVITATION,

--- a/apps/api/src/use-cases/auth/__tests__/request-password-reset.test.ts
+++ b/apps/api/src/use-cases/auth/__tests__/request-password-reset.test.ts
@@ -98,6 +98,7 @@ describe('Request Password Reset', () => {
       expect(mockEmailAgent.sendResetPasswordEmail).toHaveBeenCalledWith(
         mockUser.firstName,
         mockUser.email,
+        mockUser.role,
         mockTokenString,
         undefined
       )

--- a/apps/api/src/use-cases/auth/request-password-reset.ts
+++ b/apps/api/src/use-cases/auth/request-password-reset.ts
@@ -32,7 +32,13 @@ export const requestPasswordReset = async (
     const token = await createPasswordResetToken(user.id)
 
     emailAgent
-      .sendResetPasswordEmail(user.firstName, user.email, token, preferences)
+      .sendResetPasswordEmail(
+        user.firstName,
+        user.email,
+        user.role,
+        token,
+        preferences
+      )
       .catch((error: unknown) => {
         logger.error(
           { error },

--- a/apps/api/src/use-cases/owner/admins/__tests__/invites.test.ts
+++ b/apps/api/src/use-cases/owner/admins/__tests__/invites.test.ts
@@ -149,6 +149,7 @@ describe('inviteAdmin', () => {
     expect(mockSendUserInvitationEmail).toHaveBeenCalledWith(
       'New',
       'newadmin@example.com',
+      Role.Admin,
       'invitation-token-123',
       'New',
       'Test Company'
@@ -337,6 +338,7 @@ describe('resendAdminInvite', () => {
     expect(mockSendUserInvitationEmail).toHaveBeenCalledWith(
       'Admin',
       'admin@example.com',
+      Role.Admin,
       'new-invitation-token',
       'Owner',
       'Test Company'

--- a/apps/api/src/use-cases/owner/admins/invites.ts
+++ b/apps/api/src/use-cases/owner/admins/invites.ts
@@ -88,6 +88,7 @@ export const inviteAdmin = async (
   await emailAgent.sendUserInvitationEmail(
     newAdmin.firstName,
     newAdmin.email,
+    Role.Admin,
     token,
     inviter.firstName,
     env.COMPANY_NAME
@@ -131,6 +132,7 @@ export const resendAdminInvite = async (adminId: string, inviterId: string) => {
   await emailAgent.sendUserInvitationEmail(
     admin.firstName,
     admin.email,
+    Role.Admin,
     token,
     inviter.firstName,
     env.COMPANY_NAME

--- a/apps/api/src/use-cases/user/__tests__/invites.test.ts
+++ b/apps/api/src/use-cases/user/__tests__/invites.test.ts
@@ -183,6 +183,7 @@ describe('inviteMember', () => {
     expect(mockEmailAgent.sendUserInvitationEmail).toHaveBeenCalledWith(
       'John',
       'john@example.com',
+      Role.User,
       'invitation-token-123',
       'Admin',
       'Acme Corp'
@@ -402,6 +403,7 @@ describe('resendMemberInvite', () => {
     expect(mockEmailAgent.sendUserInvitationEmail).toHaveBeenCalledWith(
       'John',
       'john@example.com',
+      Role.User,
       'new-invitation-token',
       'Admin',
       'Acme Corp'

--- a/apps/api/src/use-cases/user/invites.ts
+++ b/apps/api/src/use-cases/user/invites.ts
@@ -5,7 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { generatePasswordHash } from '@/security/password'
 import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services/email'
-import { AuthProvider, UserStatus } from '@/types'
+import { AuthProvider, Role, UserStatus } from '@/types'
 
 export interface InviteMemberInput {
   firstName: string
@@ -105,6 +105,7 @@ export const inviteMember = async (
   await emailAgent.sendUserInvitationEmail(
     newMember.firstName,
     newMember.email,
+    Role.User,
     token,
     inviter.firstName,
     team.name
@@ -162,6 +163,7 @@ export const resendMemberInvite = async (
   await emailAgent.sendUserInvitationEmail(
     member.firstName,
     member.email,
+    Role.User,
     token,
     inviter.firstName,
     team.name


### PR DESCRIPTION
[Feature]: Replace single \`FE_BASE_URL\` with \`FE_USER_URL\` (port 5173) and \`FE_ADMIN_URL\` (port 5175) to support separate user and admin frontends
[Improvement]: Pass \`role\` to \`sendResetPasswordEmail\` and \`sendUserInvitationEmail\` so email links route to the correct frontend app
[Improvement]: Add \`getFeBaseUrl(role)\` helper in \`email-agent.ts\` to centralize URL selection logic
[Fix]: Update E2E test to navigate using the full invite link URL instead of extracting pathname