### PR TITLE
Add member count to teams list and fix correlated subqueries

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 
 set -e
 
-bun run --filter '*' lint:staged
+bun run --filter '*' --sequential lint:staged

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -12,7 +12,7 @@
     "format:fix": "prettier --write .",
     "lint": "eslint --cache src e2e",
     "lint:fix": "eslint --cache src e2e --fix",
-    "lint:staged": "lint-staged --no-stash",
+    "lint:staged": "lint-staged",
     "check": "bun run format:fix && bun run lint:fix",
     "e2e": "NODE_ENV=test playwright test -x",
     "e2e:ui": "NODE_ENV=test playwright test --ui",

--- a/apps/api/src/data/repositories/team/index.ts
+++ b/apps/api/src/data/repositories/team/index.ts
@@ -6,10 +6,10 @@ import {
   updateTeamMember
 } from './mutations'
 import {
+  findTeam,
   findTeamById,
   findTeamMember,
   findTeamMembers,
-  findTeamWithMemberCount,
   findUserTeam,
   searchTeams
 } from './queries'
@@ -22,7 +22,7 @@ const teamMutations = {
 }
 
 const teamQueries = {
-  find: findTeamWithMemberCount,
+  find: findTeam,
   findById: findTeamById,
   findUserTeam,
   search: searchTeams

--- a/apps/api/src/data/repositories/team/queries.ts
+++ b/apps/api/src/data/repositories/team/queries.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, sql } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
 
 import type { Database } from '../../clients'
@@ -17,8 +17,12 @@ import { teamMembersTable, teamsTable, usersTable } from '../../schema'
 import { buildPagination, calcOffset } from '../pagination'
 import { lastActiveSubquery } from '../refresh-token/queries'
 
-const buildWhereConditions = ({ search }: TeamSearchParams) => {
+const buildWhereConditions = ({ ids, search }: TeamSearchParams) => {
   const conditions = []
+
+  if (ids && ids.length > 0) {
+    conditions.push(inArray(teamsTable.id, ids))
+  }
 
   if (search && search.length > 0) {
     // Use concatenated expression to leverage GIN index (idx_teams_search_trgm)
@@ -70,6 +74,15 @@ export const searchTeams = async (
     teams,
     pagination: buildPagination(pagination, countResult)
   }
+}
+
+export const findTeam = async (
+  teamId: string,
+  tx?: Database
+): Promise<TeamWithMemberCount | undefined> => {
+  const result = await searchTeams({ ids: [teamId] }, { page: 1, limit: 1 }, tx)
+
+  return result.teams[0]
 }
 
 export const findTeamById = async (
@@ -132,20 +145,6 @@ export const findTeamMembers = async (
   return rows
 }
 
-export const countTeamMembers = async (
-  teamId: string,
-  tx?: Database
-): Promise<number> => {
-  const executor = tx || db
-
-  const [result] = await executor
-    .select({ value: count() })
-    .from(teamMembersTable)
-    .where(eq(teamMembersTable.teamId, teamId))
-
-  return result?.value ?? 0
-}
-
 export const findTeamMember = async (
   teamId: string,
   userId: string,
@@ -154,25 +153,6 @@ export const findTeamMember = async (
   const members = await findTeamMembers(teamId, userId, tx)
 
   return members[0]
-}
-
-export const findTeamWithMemberCount = async (
-  teamId: string,
-  tx?: Database
-): Promise<TeamWithMemberCount | undefined> => {
-  const [team, memberCount] = await Promise.all([
-    findTeamById(teamId, tx),
-    countTeamMembers(teamId, tx)
-  ])
-
-  if (!team) {
-    return undefined
-  }
-
-  return {
-    ...team,
-    memberCount
-  }
 }
 
 export const findUserTeam = async (

--- a/apps/api/src/data/repositories/team/queries.ts
+++ b/apps/api/src/data/repositories/team/queries.ts
@@ -13,9 +13,13 @@ import type {
 } from './types'
 
 import { db } from '../../clients'
-import { teamMembersTable, teamsTable, usersTable } from '../../schema'
+import {
+  refreshTokensTable,
+  teamMembersTable,
+  teamsTable,
+  usersTable
+} from '../../schema'
 import { buildPagination, calcOffset } from '../pagination'
-import { lastActiveSubquery } from '../refresh-token/queries'
 
 const buildWhereConditions = ({ ids, search }: TeamSearchParams) => {
   const conditions = []
@@ -115,8 +119,6 @@ export const findTeamMembers = async (
     whereConditions.push(eq(teamMembersTable.userId, userId))
   }
 
-  const lastActiveSq = lastActiveSubquery(executor)
-
   const rows = await executor
     .select({
       id: teamMembersTable.userId,
@@ -126,7 +128,11 @@ export const findTeamMembers = async (
       status: usersTable.status,
       createdAt: usersTable.createdAt,
       updatedAt: usersTable.updatedAt,
-      lastActive: lastActiveSq.lastActive,
+      lastActive: sql<Date | null>`(
+        SELECT MAX(${refreshTokensTable.createdAt})
+        FROM ${refreshTokensTable}
+        WHERE ${refreshTokensTable.userId} = ${teamMembersTable.userId}
+      )`,
       position: teamMembersTable.position,
       joinedAt: teamMembersTable.joinedAt,
       inviter: {
@@ -138,7 +144,6 @@ export const findTeamMembers = async (
     .from(teamMembersTable)
     .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
     .leftJoin(invitersTable, eq(teamMembersTable.invitedBy, invitersTable.id))
-    .leftJoin(lastActiveSq, eq(teamMembersTable.userId, lastActiveSq.userId))
     .where(and(...whereConditions))
     .orderBy(desc(teamMembersTable.joinedAt))
 

--- a/apps/api/src/data/repositories/team/queries.ts
+++ b/apps/api/src/data/repositories/team/queries.ts
@@ -39,9 +39,25 @@ export const searchTeams = async (
 
   const whereClause = buildWhereConditions(filters)
 
+  // Correlated subquery — executes once per returned row,
+  // hits team_members_team_index exactly N times (N = page size)
+  const memberCountSubquery = sql<number>`(
+    SELECT COUNT(*)::int
+    FROM ${teamMembersTable}
+    WHERE ${teamMembersTable.teamId} = ${teamsTable.id}
+  )`
+
   const [teams, countResult] = await Promise.all([
     executor
-      .select()
+      .select({
+        id: teamsTable.id,
+        name: teamsTable.name,
+        website: teamsTable.website,
+        description: teamsTable.description,
+        createdAt: teamsTable.createdAt,
+        updatedAt: teamsTable.updatedAt,
+        memberCount: memberCountSubquery
+      })
       .from(teamsTable)
       .where(whereClause)
       .orderBy(desc(teamsTable.createdAt))

--- a/apps/api/src/data/repositories/team/queries.ts
+++ b/apps/api/src/data/repositories/team/queries.ts
@@ -52,7 +52,7 @@ export const searchTeams = async (
   const memberCountSubquery = sql<number>`(
     SELECT COUNT(*)::int
     FROM ${teamMembersTable}
-    WHERE ${teamMembersTable.teamId} = ${teamsTable.id}
+    WHERE ${teamMembersTable.teamId} = ${sql.raw('"teams"."id"')}
   )`
 
   const [teams, countResult] = await Promise.all([

--- a/apps/api/src/data/repositories/team/types.ts
+++ b/apps/api/src/data/repositories/team/types.ts
@@ -45,6 +45,7 @@ export interface UserTeamInfo {
 }
 
 export interface TeamSearchParams {
+  ids?: string[]
   search?: string
 }
 

--- a/apps/api/src/data/repositories/team/types.ts
+++ b/apps/api/src/data/repositories/team/types.ts
@@ -49,6 +49,6 @@ export interface TeamSearchParams {
 }
 
 export interface TeamSearchResult {
-  teams: Team[]
+  teams: TeamWithMemberCount[]
   pagination: PaginatedResult
 }

--- a/apps/api/src/data/repositories/user/queries.ts
+++ b/apps/api/src/data/repositories/user/queries.ts
@@ -45,15 +45,16 @@ const selectUserExtended = (executor: Database) => {
       updatedAt: usersTable.updatedAt,
       lastActive: lastActiveSq.lastActive,
       role: sql<Role>`COALESCE(${userRoleTable.role}, ${Role.User})`,
-      team: {
-        id: teamsTable.id,
-        name: teamsTable.name
-      }
+      team: sql<{ id: string; name: string } | null>`(
+        SELECT JSON_BUILD_OBJECT('id', t.id, 'name', t.name)
+        FROM ${teamMembersTable} tm
+        JOIN ${teamsTable} t ON t.id = tm.team_id
+        WHERE tm.user_id = ${usersTable.id}
+        LIMIT 1
+      )`
     })
     .from(usersTable)
     .leftJoin(userRoleTable, eq(usersTable.id, userRoleTable.userId))
-    .leftJoin(teamMembersTable, eq(usersTable.id, teamMembersTable.userId))
-    .leftJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
     .leftJoin(lastActiveSq, eq(usersTable.id, lastActiveSq.userId))
 }
 

--- a/apps/api/src/data/repositories/user/queries.ts
+++ b/apps/api/src/data/repositories/user/queries.ts
@@ -49,7 +49,7 @@ const selectUserExtended = (executor: Database) => {
         SELECT JSON_BUILD_OBJECT('id', t.id, 'name', t.name)
         FROM ${teamMembersTable} tm
         JOIN ${teamsTable} t ON t.id = tm.team_id
-        WHERE tm.user_id = ${usersTable.id}
+        WHERE tm.user_id = ${sql.raw('"users"."id"')}
         LIMIT 1
       )`
     })

--- a/apps/api/src/use-cases/admin/__tests__/teams.test.ts
+++ b/apps/api/src/use-cases/admin/__tests__/teams.test.ts
@@ -25,7 +25,8 @@ describe('getTeams', () => {
           website: 'https://acme.com',
           description: 'A test team',
           createdAt: new Date('2024-01-01'),
-          updatedAt: new Date('2024-01-01')
+          updatedAt: new Date('2024-01-01'),
+          memberCount: 3
         }
       ],
       pagination: { page: 1, limit: 25, total: 1, totalPages: 1 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "format:fix": "prettier --write .",
     "lint": "eslint --cache src e2e",
     "lint:fix": "eslint --cache src e2e --fix",
-    "lint:staged": "lint-staged --no-stash",
+    "lint:staged": "lint-staged",
     "check": "bun run format:fix && bun run lint:fix",
     "e2e": "NODE_ENV=test playwright test -x",
     "e2e:ui": "NODE_ENV=test playwright test --ui",

--- a/packages/i18n/src/resources/en.json
+++ b/packages/i18n/src/resources/en.json
@@ -359,6 +359,7 @@
     "teams": {
       "createdAt": "$t(createdAt)",
       "id": "ID",
+      "memberCount": "Members",
       "name": "Name",
       "updatedAt": "$t(updatedAt)",
       "website": "Website"

--- a/packages/i18n/src/resources/uk.json
+++ b/packages/i18n/src/resources/uk.json
@@ -365,6 +365,7 @@
     "teams": {
       "createdAt": "$t(createdAt)",
       "id": "ID",
+      "memberCount": "Учасники",
       "name": "Назва",
       "updatedAt": "$t(updatedAt)",
       "website": "Сайт"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,7 @@
     "format:fix": "prettier --write .",
     "lint": "eslint --cache src",
     "lint:fix": "eslint --cache src --fix",
-    "lint:staged": "lint-staged --no-stash",
+    "lint:staged": "lint-staged",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",

--- a/packages/ui/src/pages/admin/Team/TeamPage.jsx
+++ b/packages/ui/src/pages/admin/Team/TeamPage.jsx
@@ -12,11 +12,12 @@ import {
 import { Tabs, TabsContent, TabsLine } from '@ui/components/ui'
 import { useHashTab } from '@ui/hooks/useHashTab'
 import { useLocale } from '@ui/hooks/useLocale'
-import { useNavigate, useParams } from '@ui/hooks/useRouter'
+import { useLocation, useNavigate, useParams } from '@ui/hooks/useRouter'
 import { useTeam } from '@ui/hooks/useTeam'
 
 export const TeamPage = () => {
   const { id: teamId } = useParams()
+  const { state } = useLocation()
   const navigate = useNavigate()
   const { t } = useLocale()
   const [activeTab, setActiveTab] = useHashTab(
@@ -24,7 +25,15 @@ export const TeamPage = () => {
     TeamTab.GENERAL
   )
 
-  const { data: team, isPending, isError, error, refetch } = useTeam(teamId)
+  const {
+    data: team,
+    isPending,
+    isError,
+    error,
+    refetch
+  } = useTeam(teamId, {
+    initialData: state?.team ? { team: state.team } : undefined
+  })
 
   if (isError) {
     return <ErrorState error={error} onRetry={refetch} />

--- a/packages/ui/src/pages/admin/Teams/TeamsPage.jsx
+++ b/packages/ui/src/pages/admin/Teams/TeamsPage.jsx
@@ -45,7 +45,8 @@ export const TeamsPage = () => {
   )
   const [sorting, setSorting] = useState([])
 
-  const viewTeam = team => navigate(`/admin/teams/${team.id}`)
+  const viewTeam = team =>
+    navigate(`/admin/teams/${team.id}`, { state: { team } })
 
   const contextMenu = [createOpenItem(t, viewTeam, Users)]
 

--- a/packages/ui/src/pages/admin/Teams/columns.jsx
+++ b/packages/ui/src/pages/admin/Teams/columns.jsx
@@ -17,6 +17,11 @@ export const getColumns = (t, formatDate) => {
       header: label('website')
     },
     {
+      accessorKey: 'memberCount',
+      header: label('memberCount'),
+      cell: info => info.getValue() || '—'
+    },
+    {
       accessorKey: 'createdAt',
       header: label('createdAt'),
       cell: info => formatDate(info.getValue())


### PR DESCRIPTION
[Feature]: Add Members column to TeamsPage showing member count per team with em dash for empty teams
[Fix]: Fix correlated subqueries using sql.raw for table-qualified column refs to prevent Drizzle parameterization bug
[Improvement]: Pass team state when navigating to TeamPage for instant render without waiting for API
[Fix]: Fix pre-commit hook race condition by switching workspace lint-staged runs to sequential mode
[Improvement]: Remove --no-stash workaround from ui/web/admin packages now that sequential mode eliminates the race
[Improvement]: Inline team lookup as correlated subquery in selectUserExtended, removing two redundant LEFT JOINs