### PR TITLE
Update Claude code review workflow prompts

### DIFF
--- a/.github/workflows/api-claude-code-review.yml
+++ b/.github/workflows/api-claude-code-review.yml
@@ -43,53 +43,28 @@ jobs:
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide a quality assessment score (1–10) for each of the following criteria:
+            Review this pull request (Bun + Hono + TypeScript API). Score each area 1–10. Be concise — one short justification per section, max 3 actionable issues if any.
 
-            - **Architecture** (1–10):
+            Scoring criteria:
+            - **🏗️ Architecture**: DRY, SOLID, modularity, low coupling. Adjust ±1 for data layer (schema, transactions, indexing) or infra (cache, queues, retries) if relevant.
+            - **🛡️ Security**: Input validation, auth/RBAC enforcement, no data leaks, no injection/XSS/CSRF.
+            - **🧪 Testing**: ~60% coverage on critical paths and business logic. Clear and reliable tests.
+            - **⚡ Performance**: Efficiency under load. Flag only real issues, not speculative.
+            - **💎 Code Quality**: Readable, maintainable, names express intent. ESLint and CLAUDE.md compliant.
 
-              Each dimension is scored 1–10 and averaged:
-                1. **DRY Principle** — Avoids duplication; variables/functions/classes/modules reused appropriately. Lower score for duplicated code blocks.
-                2. **SOLID Principles** — Each principle contributes up to 2 points (S, O, L, I, D). Partial implementation = 1; not applicable or nicely implemented = 2; violation = 0.
-                3. **Design Patterns & Simplicity** — Appropriate use of creational/structural/behavioral patterns or clean simplicity if no pattern is needed. Lower score for over-engineering or missing abstraction are now acceptable.
-                4. **Modularity, Coupling & Cohesion** — Modules have single, focused purposes; minimal cross-dependencies. Higher score for clear boundaries and well-defined interfaces, lower score for circular imports or mixed logic.
+            DO NOT suggest:
+            - JSDoc or obvious inline comments
+            - Stylistic nitpicks
+            - Trivial renames
+            - Explicit return types when TypeScript infers correctly
 
-              Optional backend modifiers:
-                If relevant, adjust ±1–2 points based on backend considerations:
-                  - Data layer design (schema quality, transactions, indexing).
-                  - Infrastructure integration (cache, queues, 3rd-party services).
-                  - Scalability & fault isolation (read/write separation, retries, timeouts)
-
-              **Scoring interpretation**
-                - 10 (Excellent) - fully aligned with best practices (DRY + SOLID + modular + patterns where appropriate).
-                - 8–9 (Strong) - minor issues but overall clean and well-designed.
-                - 6–7 (Moderate) - some inconsistencies or partial adherence to principles.
-                - 4–5 (Weak) - architectural problems (duplication, unclear boundaries, tight coupling).
-                - 1–3 (Poor) - serious structural issues; likely needs refactoring.
-
-            - **Security** (1–10): Check that inputs are validated, authentication and permissions are enforced (including role-based access control), sensitive data is protected, and no obvious vulnerabilities exist (injection, XSS, CSRF). Ensure errors don't leak sensitive information.
-            - **Testing** (1–10): Check that tests cover at least the main logic (~60%), are clear, reliable, and easy to maintain. Focus on meaningful coverage and critical paths (main user flows and business logic) rather than chasing 100%.
-            - **Performance** (1–10): Check this update for efficiency, resource usage, and scalability. Identify any optimization opportunities or performance implications, especially under high load or large data scenarios.
-            - **Code Quality** (1–10): Check this code for readability, maintainability, adherence to ESLint and CLAUDE.md standards, and naming clarity. Favor clarity over cleverness, and ensure names express intent clearly.
-
-            **DO NOT suggest any of the following:**
-            - Adding JSDoc comments or documentation comments (code should be self-documenting)
-            - Adding inline comments for obvious logic
-            - Minor stylistic preferences that don't affect correctness
-            - Trivial renaming suggestions unless names are genuinely misleading
-            - Adding explicit return types when TypeScript can infer them correctly
-
-            Format the assessment as:
+            Format:
 
             ```md
-            ## Quality Assessment:
-
-            <!-- Use the same "Brief justification" and "Optional suggestions for improvement" format for all sections below except "Overall". -->
+            ## Quality Assessment
 
             ### 🏗️ Architecture: X/10
-            [Brief justification — keep it short and clear.]
-
-            [Optional suggestions for improvement — list only critical (🔴) and medium (🟠) priority issues.
-            Skip low-priority polish items. Use an enumerated list ordered by priority.]
+            [One sentence justification. Issues if any — 🔴 critical first, then 🟠 medium. Max 3.]
 
             ### 🛡️ Security: X/10
 
@@ -99,5 +74,5 @@ jobs:
 
             ### 💎 Code Quality: X/10
 
-            ### [Use ✅ if overall score ≥ 8 or ⚠️ if score < 8] Overall: X/10
+            ### [✅ if overall ≥ 8, ⚠️ if < 8] Overall: X/10
             ```

--- a/.github/workflows/web-claude-code-review.yml
+++ b/.github/workflows/web-claude-code-review.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize]
     paths:
       - 'apps/web/**'
+      - 'apps/admin/**'
+      - 'packages/ui/**'
+      - 'packages/i18n/**'
 
 jobs:
   claude-code-review:
@@ -44,22 +47,24 @@ jobs:
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request for a Vite + React (JavaScript) frontend application.
+            Please review this pull request. It may touch one or more of: apps/web, apps/admin (Vite + React JS apps), packages/ui (shared React component library), or packages/i18n (i18n/translation resources — no components, focus on key naming and missing translations).
 
             Review areas:
             1. Code quality and best practices
             2. Potential bugs or issues
             3. Performance considerations (only flag obvious issues, not speculative optimizations)
             4. Security concerns
-            5. Test coverage: We aim for 40-60% coverage, not 100%. In real development with limited team size (might be solo dev), we focus on minimum testable solution. Prefer a few tests covering normal flow plus a few edge cases. When issues arise, we add unit tests to prevent regression. We can focus on comprehensive testing later if needed.
+            5. Test coverage: ~40% unit test coverage is sufficient — Storybook covers component behavior and Playwright E2E covers critical user flows. Unit tests should target logic, not UI. Add regression tests only when a bug is fixed.
 
             Format your feedback:
+              - Be concise — no verbose explanations, no padding
+              - Cap any list (suggestions, benefits, examples) at 3 items max
               - Group issues by priority:
                 * **Critical**: Bugs, security vulnerabilities, breaking changes — must fix
-                * **Medium**: Important improvements to address
-                * Skip low-priority nitpicks
-              - Include code examples for each suggestion
+                * **Suggestions**: Important improvements to address
+              - Include a short code example only when the fix is non-obvious
               - Do NOT include a "Review Summary" section (summaries are in PR descriptions)
+              - Do NOT include a "Positive Observations", "Test Coverage Assessment", "Security & Performance" section at the end
 
               DO NOT suggest:
               - JSDoc comments (only comment genuinely complex logic)


### PR DESCRIPTION
[Improvement]: Expand web review workflow to cover apps/admin, packages/ui, and packages/i18n in addition to apps/web
[Improvement]: Tighten web review prompt — concise output, max 3 items per list, suppress "Positive Observations" and other noise sections
[Improvement]: Update test coverage guidance to reflect Storybook + Playwright strategy (~40% unit coverage is sufficient)
[Improvement]: Condense API review prompt from ~60 lines to ~30 — same scoring criteria, verbose explanations removed, max 3 issues per section