### PR TITLE
Restrict admin auth routes and add login E2E tests

### DIFF
--- a/apps/admin/e2e/auth.spec.js
+++ b/apps/admin/e2e/auth.spec.js
@@ -1,0 +1,22 @@
+import { expect, test } from './config/fixtures'
+
+test.describe('Auth', () => {
+  test('login page has no signup prompt and no Google login button', async ({
+    page,
+    t
+  }) => {
+    await page.goto('/login')
+
+    await expect(page.getByText(t.doNotHaveAccount)).not.toBeVisible()
+    await expect(
+      page.getByRole('button', { name: t.continueWithGoogle })
+    ).not.toBeVisible()
+  })
+
+  test('/signup route renders 404 page', async ({ page, t }) => {
+    await page.goto('/signup')
+
+    await expect(page.getByTestId('not-found-error-page')).toBeVisible()
+    await expect(page.getByText(t.error.notFound.title)).toBeVisible()
+  })
+})

--- a/apps/admin/src/router.jsx
+++ b/apps/admin/src/router.jsx
@@ -10,11 +10,8 @@ import {
 } from '@smela/ui/pages/admin'
 import {
   AcceptInvitePage,
-  EmailConfirmationPage,
   LoginPage,
-  ResetPasswordPage,
-  SignupPage,
-  VerifyEmailPage
+  ResetPasswordPage
 } from '@smela/ui/pages/auth'
 import {
   GeneralErrorPage,
@@ -44,12 +41,16 @@ export const router = createBrowserRouter([
     ),
     errorElement: <ErrorBoundary />,
     children: [
-      { path: 'login', element: <LoginPage /> },
-      { path: 'signup', element: <SignupPage /> },
+      {
+        path: 'login',
+        element: (
+          <LoginPage
+            options={{ showSignupPrompt: false, showSocialLogin: false }}
+          />
+        )
+      },
       { path: 'reset-password', element: <ResetPasswordPage /> },
-      { path: 'accept-invite', element: <AcceptInvitePage /> },
-      { path: 'email-confirmation', element: <EmailConfirmationPage /> },
-      { path: 'verify-email', element: <VerifyEmailPage /> }
+      { path: 'accept-invite', element: <AcceptInvitePage /> }
     ]
   },
   {

--- a/packages/ui/src/pages/admin/Teams/columns.jsx
+++ b/packages/ui/src/pages/admin/Teams/columns.jsx
@@ -19,7 +19,7 @@ export const getColumns = (t, formatDate) => {
     {
       accessorKey: 'memberCount',
       header: label('memberCount'),
-      cell: info => info.getValue() || '—'
+      cell: info => info.getValue() || ''
     },
     {
       accessorKey: 'createdAt',

--- a/packages/ui/src/pages/auth/Login/LoginPage.jsx
+++ b/packages/ui/src/pages/auth/Login/LoginPage.jsx
@@ -19,11 +19,6 @@ const defaultOptions = {
 }
 
 export const LoginPage = ({ options = {} }) => {
-  const { showSignupPrompt, showSocialLogin } = {
-    ...defaultOptions,
-    ...options
-  }
-
   const { t, te } = useLocale()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -32,6 +27,11 @@ export const LoginPage = ({ options = {} }) => {
     useLoginWithGoogle()
   const { showErrorToast } = useToast()
   const { captchaRef, getCaptchaToken } = useCaptcha()
+
+  const { showSignupPrompt, showSocialLogin } = {
+    ...defaultOptions,
+    ...options
+  }
 
   const handleLogin = async data => {
     const token = await getCaptchaToken()

--- a/packages/ui/src/pages/auth/Login/LoginPage.jsx
+++ b/packages/ui/src/pages/auth/Login/LoginPage.jsx
@@ -13,7 +13,17 @@ import { useToast } from '@ui/hooks/useToast'
 import { AuthRoot } from '../Auth'
 import { LoginForm } from './Form'
 
-export const LoginPage = () => {
+const defaultOptions = {
+  showSignupPrompt: true,
+  showSocialLogin: true
+}
+
+export const LoginPage = ({ options = {} }) => {
+  const { showSignupPrompt, showSocialLogin } = {
+    ...defaultOptions,
+    ...options
+  }
+
   const { t, te } = useLocale()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -66,22 +76,26 @@ export const LoginPage = () => {
         <div className='flex flex-col gap-2'>
           <LoginForm isLoading={isEmailPending} onSubmit={handleLogin} />
 
-          <TextSeparator text={t('or')} />
+          {showSocialLogin && (
+            <>
+              <TextSeparator text={t('or')} />
 
-          <div className='flex flex-col gap-4'>
-            <Button
-              variant='outline'
-              className='w-full'
-              onClick={handleLoginWithGoogle}
-              disabled={isGooglePending}
-            >
-              <GoogleIcon />
-              {t('continueWithGoogle')}
-            </Button>
-          </div>
+              <div className='flex flex-col gap-4'>
+                <Button
+                  variant='outline'
+                  className='w-full'
+                  onClick={handleLoginWithGoogle}
+                  disabled={isGooglePending}
+                >
+                  <GoogleIcon />
+                  {t('continueWithGoogle')}
+                </Button>
+              </div>
+            </>
+          )}
         </div>
 
-        <SignupPrompt />
+        {showSignupPrompt && <SignupPrompt />}
 
         <ForgotYourPasswordPrompt />
       </AuthRoot>


### PR DESCRIPTION
[Feature]: Add `options` prop to `LoginPage` to hide signup prompt and social login per app
[Improvement]: Admin login hides Google button and signup prompt — invite-only by design
[Fix]: Remove `/signup`, `/email-confirmation`, and `/verify-email` routes from admin router — signup flow irrelevant for admin
[Feature]: Add `apps/admin/e2e/auth.spec.js` with tests for absent signup UI and 404 on `/signup`