### PR TITLE
Normalize package versions to 0.0.1

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smela/e2e",
-  "version": "2026.04.20",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smela/eslint",
-  "version": "2026.04.20",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smela/i18n",
-  "version": "2026.04.20",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smela/ui",
-  "version": "2026.04.20",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
[Improvement]: Normalize package versions across all packages from date-based versioning to standard semantic versioning

All packages now use version 0.0.1 instead of the previous 2026.04.20 format for consistency with semantic versioning standards.