### PR TITLE
Add permission-based RBAC to useHasAccess

### DIFF
--- a/packages/ui/src/hooks/__tests__/useHasAccess.test.js
+++ b/packages/ui/src/hooks/__tests__/useHasAccess.test.js
@@ -1,0 +1,135 @@
+import { renderHook } from '@testing-library/react'
+
+import { useCurrentUser } from '../useAuth'
+import { useHasAccess } from '../useHasAccess'
+
+vi.mock('../useAuth')
+
+const authenticated = (overrides = {}) => ({
+  isFetching: false,
+  isAuthenticated: true,
+  user: {
+    status: 'active',
+    role: 'user',
+    permissions: [],
+    ...overrides
+  }
+})
+
+describe('useHasAccess', () => {
+  beforeEach(() => {
+    useCurrentUser.mockClear()
+  })
+
+  it('denies when not authenticated', () => {
+    useCurrentUser.mockReturnValue({
+      isFetching: false,
+      isAuthenticated: false,
+      user: null
+    })
+
+    const { result } = renderHook(() => useHasAccess())
+
+    expect(result.current.hasAccess).toBe(false)
+  })
+
+  it('allows when no requirements and authenticated', () => {
+    useCurrentUser.mockReturnValue(authenticated())
+
+    const { result } = renderHook(() => useHasAccess())
+
+    expect(result.current.hasAccess).toBe(true)
+  })
+
+  it('returns isFetching true while fetching', () => {
+    useCurrentUser.mockReturnValue({
+      isFetching: true,
+      isAuthenticated: false,
+      user: null
+    })
+
+    const { result } = renderHook(() => useHasAccess())
+
+    expect(result.current.isFetching).toBe(true)
+  })
+
+  describe('requireStatuses', () => {
+    it('allows when user status matches', () => {
+      useCurrentUser.mockReturnValue(authenticated({ status: 'active' }))
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requireStatuses: ['active'] })
+      )
+
+      expect(result.current.hasAccess).toBe(true)
+    })
+
+    it('denies when user status does not match', () => {
+      useCurrentUser.mockReturnValue(authenticated({ status: 'pending' }))
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requireStatuses: ['active'] })
+      )
+
+      expect(result.current.hasAccess).toBe(false)
+    })
+  })
+
+  describe('requireRoles', () => {
+    it('allows when user role matches', () => {
+      useCurrentUser.mockReturnValue(authenticated({ role: 'admin' }))
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requireRoles: ['admin'] })
+      )
+
+      expect(result.current.hasAccess).toBe(true)
+    })
+
+    it('denies when user role does not match', () => {
+      useCurrentUser.mockReturnValue(authenticated({ role: 'user' }))
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requireRoles: ['admin'] })
+      )
+
+      expect(result.current.hasAccess).toBe(false)
+    })
+  })
+
+  describe('requirePermissions', () => {
+    it('allows when user has all required permissions', () => {
+      useCurrentUser.mockReturnValue(
+        authenticated({ permissions: ['manage:users', 'view:teams'] })
+      )
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requirePermissions: ['manage:users', 'view:teams'] })
+      )
+
+      expect(result.current.hasAccess).toBe(true)
+    })
+
+    it('denies when user is missing one required permission', () => {
+      useCurrentUser.mockReturnValue(
+        authenticated({ permissions: ['view:users'] })
+      )
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requirePermissions: ['view:users', 'manage:users'] })
+      )
+
+      expect(result.current.hasAccess).toBe(false)
+    })
+
+    it('allows when requirePermissions is empty', () => {
+      useCurrentUser.mockReturnValue(authenticated({ permissions: [] }))
+
+      const { result } = renderHook(() =>
+        useHasAccess({ requirePermissions: [] })
+      )
+
+      expect(result.current.hasAccess).toBe(true)
+    })
+  })
+})

--- a/packages/ui/src/hooks/useHasAccess.js
+++ b/packages/ui/src/hooks/useHasAccess.js
@@ -2,7 +2,8 @@ import { useCurrentUser } from '@ui/hooks/useAuth'
 
 export const useHasAccess = ({
   requireStatuses = [],
-  requireRoles = []
+  requireRoles = [],
+  requirePermissions = []
 } = {}) => {
   const { isFetching, isAuthenticated, user: me } = useCurrentUser()
 
@@ -12,13 +13,15 @@ export const useHasAccess = ({
   const hasRequiredRole =
     requireRoles.length === 0 || requireRoles.includes(me?.role)
 
-  const hasAccess = isAuthenticated && hasRequiredStatus && hasRequiredRole
+  const hasRequiredPermissions =
+    requirePermissions.length === 0 ||
+    requirePermissions.every(p => me?.permissions?.includes(p))
 
-  return {
-    isFetching,
-    isAuthenticated,
-    hasAccess,
-    status: me?.status || null,
-    role: me?.role || null
-  }
+  const hasAccess =
+    isAuthenticated &&
+    hasRequiredStatus &&
+    hasRequiredRole &&
+    hasRequiredPermissions
+
+  return { isFetching, isAuthenticated, hasAccess }
 }

--- a/packages/ui/src/routes/guards/PrivateRoute.jsx
+++ b/packages/ui/src/routes/guards/PrivateRoute.jsx
@@ -7,11 +7,13 @@ import { NotFoundErrorPage } from '@ui/pages/errors'
 export const PrivateRoute = ({
   children,
   requireStatuses = [],
-  requireRoles = []
+  requireRoles = [],
+  requirePermissions = []
 }) => {
   const { isFetching, isAuthenticated, hasAccess } = useHasAccess({
     requireStatuses,
-    requireRoles
+    requireRoles,
+    requirePermissions
   })
 
   if (isFetching) {


### PR DESCRIPTION
[Feature]: Add `requirePermissions` prop to `PrivateRoute` for fine-grained route access control
[Feature]: Extend `useHasAccess` hook with permission checks using AND semantics (all required permissions must be present)
[Improvement]: Remove unused `status` and `role` fields from `useHasAccess` return value
[Feature]: Add unit tests for `useHasAccess` covering status, role, and permission access scenarios