### PR TITLE
Guard verify-email page against missing token

### DIFF
--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -409,11 +409,10 @@ test.describe('Authentication: General', () => {
     const url = new URL(link)
     const originalToken = url.searchParams.get('token')
 
-    // 1: Empty token
+    // 1: Empty token — frontend silently redirects to / without API call,
+    // then status guard redirects new user back to /email-confirmation
     await page.goto(`${url.origin}${url.pathname}?token=`)
-    // No API call is made for empty token - frontend handles it
-
-    await expect(page.getByText(t.backend['validation/error'])).toBeVisible()
+    await page.waitForURL(/email-confirmation/)
 
     // 2: Malformed token (replace last char with underscore)
     const malformedToken = originalToken.slice(0, -1) + '_'

--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -522,6 +522,18 @@ test.describe('Authentication: General', () => {
     await logOut(page, t)
   })
 
+  test('verify-email / accept-invite: redirects unauthenticated users without token to login', async ({
+    page
+  }) => {
+    const paths = ['/verify-email', '/accept-invite']
+
+    for (const path of paths) {
+      await page.goto(path)
+      await page.waitForURL('/login')
+      await expect(page).toHaveURL(/\/login/)
+    }
+  })
+
   test('authorization: shows 404 for unauthorized and unknown routes', async ({
     page,
     t,

--- a/packages/ui/src/hooks/useVerifyEmailOnce.js
+++ b/packages/ui/src/hooks/useVerifyEmailOnce.js
@@ -13,7 +13,7 @@ export const useVerifyEmailOnce = (token, { onSettled }) => {
   const hasVerified = useRef(false)
 
   useEffect(() => {
-    if (hasVerified.current) {
+    if (!token || hasVerified.current) {
       return
     }
 

--- a/packages/ui/src/pages/auth/VerifyEmail/VerifyEmailPage.jsx
+++ b/packages/ui/src/pages/auth/VerifyEmail/VerifyEmailPage.jsx
@@ -4,12 +4,19 @@ import { useNavigate } from '@ui/hooks/useRouter'
 import { useToast } from '@ui/hooks/useToast'
 import { useUrlParams } from '@ui/hooks/useUrlParams'
 import { useVerifyEmailOnce } from '@ui/hooks/useVerifyEmailOnce'
+import { useEffect } from 'react'
 
 export const VerifyEmailPage = () => {
   const { t, te } = useLocale()
   const { showErrorToast, showSuccessToast } = useToast()
   const navigate = useNavigate()
   const { token } = useUrlParams(['token'])
+
+  useEffect(() => {
+    if (!token) {
+      navigate('/', { replace: true })
+    }
+  }, [token, navigate])
 
   useVerifyEmailOnce(token, {
     onSettled: (data, error) => {
@@ -24,6 +31,10 @@ export const VerifyEmailPage = () => {
       navigate('/')
     }
   })
+
+  if (!token) {
+    return null
+  }
 
   return <Spinner />
 }


### PR DESCRIPTION
[Fix]: Redirect unauthenticated users silently to login when visiting \`/verify-email\` or \`/accept-invite\` without a token — prevents spurious error toast from firing
[Fix]: Add \`!token\` guard in \`useVerifyEmailOnce\` hook so no backend request fires when token is absent
[Feature]: Add E2E test covering both \`/verify-email\` and \`/accept-invite\` redirect behavior for unauthenticated users with no token
[Fix]: Update empty-token E2E assertion to follow full redirect chain (/ → /email-confirmation) instead of checking stale error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)