### PR TITLE
Guard email-confirmation page against unauthenticated access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@
 - `apps/api` — Bun/Hono backend (see [apps/api/CLAUDE.md](apps/api/CLAUDE.md))
 - `apps/web` — React/Vite frontend (see
   [apps/web/CLAUDE.md](apps/web/CLAUDE.md))
-- `apps/admin` — Admin interface
+- `apps/admin` — Admin interface (see
+  [apps/admin/CLAUDE.md](apps/admin/CLAUDE.md))
 
 ### Packages
 
@@ -24,6 +25,7 @@
 - [Git](https://git-scm.com/)
 - [Bun](https://bun.sh/) (see [.bun-version](.bun-version))
 - [tmux](https://github.com/tmux/tmux/wiki)
+- [Docker](https://www.docker.com/) for running PostgreSQL
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Starter kit for full-stack web apps
 
 ## Prerequisites
 
-![Stack](https://go-skill-icons.vercel.app/api/icons?i=git,bun,tmux&theme=dark&titles=true)
+![Stack](https://go-skill-icons.vercel.app/api/icons?i=git,bun,tmux,docker&theme=dark&titles=true)

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -7,7 +7,6 @@ and modularity.
 
 Besides [root prerequisites](../../README.md#-prerequisites) we need:
 
-- [Docker](https://www.docker.com/) for running PostgreSQL
 - Email service account ([Resend](https://resend.com/) for production,
   [Ethereal](https://ethereal.email/) for development)
 

--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -521,10 +521,10 @@ test.describe('Authentication: General', () => {
     await logOut(page, t)
   })
 
-  test('verify-email / accept-invite: redirects unauthenticated users without token to login', async ({
+  test('verify-email / accept-invite / email-confirmation: redirects unauthenticated users without required context to login', async ({
     page
   }) => {
-    const paths = ['/verify-email', '/accept-invite']
+    const paths = ['/verify-email', '/accept-invite', '/email-confirmation']
 
     for (const path of paths) {
       await page.goto(path)

--- a/packages/ui/src/pages/auth/EmailConfirmation/EmailConfirmationPage.jsx
+++ b/packages/ui/src/pages/auth/EmailConfirmation/EmailConfirmationPage.jsx
@@ -3,7 +3,7 @@ import { EmailLink } from '@ui/components/links'
 import { useCurrentUser, useResendVerificationEmail } from '@ui/hooks/useAuth'
 import { useCaptcha } from '@ui/hooks/useCaptcha'
 import { useLocale } from '@ui/hooks/useLocale'
-import { useLocation } from '@ui/hooks/useRouter'
+import { Navigate, useLocation } from '@ui/hooks/useRouter'
 import { useTheme } from '@ui/hooks/useTheme'
 import { useToast } from '@ui/hooks/useToast'
 
@@ -17,10 +17,14 @@ export const EmailConfirmationPage = () => {
   const { mutate: resendVerificationEmail, isPending } =
     useResendVerificationEmail()
   const { showSuccessToast, showErrorToast } = useToast()
-  const { user: me } = useCurrentUser()
+  const { isFetching, user: me } = useCurrentUser()
   const { captchaRef, getCaptchaToken } = useCaptcha()
 
   const email = location.state?.email || me?.email
+
+  if (!isFetching && !email) {
+    return <Navigate to='/' replace />
+  }
 
   const handleResendVerificationEmail = async data => {
     const token = await getCaptchaToken()


### PR DESCRIPTION
## Changes

[Fix]: Redirect unauthenticated users from \`/email-confirmation\` to \`/\` when no email context is available
[Improvement]: Update E2E test to cover \`/email-confirmation\` redirect alongside \`/verify-email\` and \`/accept-invite\`
[Improvement]: Add Docker to root prerequisites and remove duplicate entry from \`apps/api/README.md\`
[Improvement]: Add \`apps/admin/CLAUDE.md\` reference to project knowledge base