### PR TITLE
Improve admin invite E2E test coverage

### DIFF
--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -10,11 +10,7 @@ import { generateEmailAddress } from '@smela/e2e/email'
 import { HttpStatus } from '@smela/ui/lib/net'
 import {
   ACCEPT_INVITE_PATH,
-  ADMIN_TEAMS_PATH,
-  ADMIN_USER_PATH,
-  ADMIN_USERS_PATH,
   OWNER_ADMINS_PATH,
-  TEAMS_PATH,
   UPDATE_PASSWORD_PATH
 } from '@smela/ui/services/backend/paths'
 
@@ -210,36 +206,17 @@ test.describe.serial('Owner: Invite admin with full access', () => {
   }) => {
     await login({ email: newAdmin.email, password: newAdmin.password })
 
-    const teamsLoadPromise = waitForApiCall(page, {
-      path: ADMIN_TEAMS_PATH,
-      status: HttpStatus.OK
-    })
-
     await page.goto('/admin/teams')
-    await teamsLoadPromise
 
     // Manage permission: Add button must be visible
     await expect(page.getByRole('button', { name: t.add })).toBeVisible()
 
     // Open the first team row
-    const firstTeamRow = page.getByRole('row').nth(1)
-    const firstTeamName = await firstTeamRow
-      .getByRole('cell')
-      .first()
-      .innerText()
+    await page.getByRole('row').nth(1).click()
 
-    const teamDetailPromise = waitForApiCall(page, {
-      path: TEAMS_PATH.replace(':teamId', ''),
-      method: 'GET',
-      status: HttpStatus.OK
-    })
-
-    await firstTeamRow.click()
-    await teamDetailPromise
-
-    // View + manage permission: Name field must be editable
+    // View + manage permission: Name and description fields must be editable
     await expect(page.getByLabel(t.team.name.label)).not.toBeDisabled()
-    await expect(page.getByLabel(t.team.name.label)).toHaveValue(firstTeamName)
+    await expect(page.getByLabel(t.team.description.label)).not.toBeDisabled()
 
     await logOut(page, t)
   })
@@ -251,25 +228,10 @@ test.describe.serial('Owner: Invite admin with full access', () => {
   }) => {
     await login({ email: newAdmin.email, password: newAdmin.password })
 
-    const usersLoadPromise = waitForApiCall(page, {
-      path: ADMIN_USERS_PATH,
-      status: HttpStatus.OK
-    })
-
     await page.goto('/admin/users')
-    await usersLoadPromise
 
     // Open the first user row
-    const firstUserRow = page.getByRole('row').nth(1)
-
-    const userDetailPromise = waitForApiCall(page, {
-      path: ADMIN_USER_PATH.replace(':userId', ''),
-      method: 'GET',
-      status: HttpStatus.OK
-    })
-
-    await firstUserRow.click()
-    await userDetailPromise
+    await page.getByRole('row').nth(1).click()
 
     // View + manage permission: firstName and lastName fields must be editable
     await expect(page.getByLabel(t.firstName.label)).not.toBeDisabled()

--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -112,7 +112,11 @@ test.describe.serial('Owner: Admin Invitation', () => {
     password: process.env.VITE_E2E_DEFAULT_PASSWORD
   }
 
-  test('owner invites admin via modal form', async ({ page, t, login }) => {
+  test('owner invites admin via modal form with default permissions (full access)', async ({
+    page,
+    t,
+    login
+  }) => {
     await login(ownerCredentials)
 
     const apiPromise = waitForApiCall(page, {
@@ -171,7 +175,12 @@ test.describe.serial('Owner: Admin Invitation', () => {
 
     const apiPromise = waitForApiCall(page, {
       path: ACCEPT_INVITE_PATH,
-      status: HttpStatus.OK
+      status: HttpStatus.OK,
+      validateResponse: body =>
+        Array.isArray(body.permissions) &&
+        ['manage:users', 'manage:teams', 'view:users', 'view:teams'].every(p =>
+          body.permissions.includes(p)
+        )
     })
 
     await fillAcceptInviteFormAndSubmit(page, newAdmin.password, t)

--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -105,7 +105,7 @@ test.describe('Owner: Admins Page', () => {
   })
 })
 
-test.describe.serial('Owner: Admin Invitation', () => {
+test.describe.serial('Owner: Invite admin with full access', () => {
   const firstName = faker.person.firstName()
   const lastName = faker.person.lastName()
 
@@ -116,11 +116,7 @@ test.describe.serial('Owner: Admin Invitation', () => {
     password: process.env.VITE_E2E_DEFAULT_PASSWORD
   }
 
-  test('owner invites admin via modal form with default permissions (full access)', async ({
-    page,
-    t,
-    login
-  }) => {
+  test('owner invites admin via modal form', async ({ page, t, login }) => {
     await login(ownerCredentials)
 
     const apiPromise = waitForApiCall(page, {
@@ -180,11 +176,20 @@ test.describe.serial('Owner: Admin Invitation', () => {
     const apiPromise = waitForApiCall(page, {
       path: ACCEPT_INVITE_PATH,
       status: HttpStatus.OK,
-      validateResponse: body =>
-        Array.isArray(body.permissions) &&
-        ['manage:users', 'manage:teams', 'view:users', 'view:teams'].every(p =>
-          body.permissions.includes(p)
+      validateResponse: body => {
+        const expected = [
+          'manage:users',
+          'manage:teams',
+          'view:users',
+          'view:teams'
+        ]
+
+        return (
+          Array.isArray(body.permissions) &&
+          body.permissions.length === expected.length &&
+          expected.every(p => body.permissions.includes(p))
         )
+      }
     })
 
     await fillAcceptInviteFormAndSubmit(page, newAdmin.password, t)
@@ -198,14 +203,13 @@ test.describe.serial('Owner: Admin Invitation', () => {
     await logOut(page, t)
   })
 
-  test('invited admin has full access to teams and users resources', async ({
+  test('invited admin can manage teams resource', async ({
     page,
     t,
     login
   }) => {
     await login({ email: newAdmin.email, password: newAdmin.password })
 
-    // --- Teams: view + manage ---
     const teamsLoadPromise = waitForApiCall(page, {
       path: ADMIN_TEAMS_PATH,
       status: HttpStatus.OK
@@ -237,7 +241,16 @@ test.describe.serial('Owner: Admin Invitation', () => {
     await expect(page.getByLabel(t.team.name.label)).not.toBeDisabled()
     await expect(page.getByLabel(t.team.name.label)).toHaveValue(firstTeamName)
 
-    // --- Users: view + manage ---
+    await logOut(page, t)
+  })
+
+  test('invited admin can manage users resource', async ({
+    page,
+    t,
+    login
+  }) => {
+    await login({ email: newAdmin.email, password: newAdmin.password })
+
     const usersLoadPromise = waitForApiCall(page, {
       path: ADMIN_USERS_PATH,
       status: HttpStatus.OK

--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -10,7 +10,11 @@ import { generateEmailAddress } from '@smela/e2e/email'
 import { HttpStatus } from '@smela/ui/lib/net'
 import {
   ACCEPT_INVITE_PATH,
+  ADMIN_TEAMS_PATH,
+  ADMIN_USER_PATH,
+  ADMIN_USERS_PATH,
   OWNER_ADMINS_PATH,
+  TEAMS_PATH,
   UPDATE_PASSWORD_PATH
 } from '@smela/ui/services/backend/paths'
 
@@ -190,6 +194,73 @@ test.describe.serial('Owner: Admin Invitation', () => {
     await expect(page.getByText(t.invite.accept.success)).toBeVisible()
 
     await page.waitForURL('/admin/dashboard')
+
+    await logOut(page, t)
+  })
+
+  test('invited admin has full access to teams and users resources', async ({
+    page,
+    t,
+    login
+  }) => {
+    await login({ email: newAdmin.email, password: newAdmin.password })
+
+    // --- Teams: view + manage ---
+    const teamsLoadPromise = waitForApiCall(page, {
+      path: ADMIN_TEAMS_PATH,
+      status: HttpStatus.OK
+    })
+
+    await page.goto('/admin/teams')
+    await teamsLoadPromise
+
+    // Manage permission: Add button must be visible
+    await expect(page.getByRole('button', { name: t.add })).toBeVisible()
+
+    // Open the first team row
+    const firstTeamRow = page.getByRole('row').nth(1)
+    const firstTeamName = await firstTeamRow
+      .getByRole('cell')
+      .first()
+      .innerText()
+
+    const teamDetailPromise = waitForApiCall(page, {
+      path: TEAMS_PATH.replace(':teamId', ''),
+      method: 'GET',
+      status: HttpStatus.OK
+    })
+
+    await firstTeamRow.click()
+    await teamDetailPromise
+
+    // View + manage permission: Name field must be editable
+    await expect(page.getByLabel(t.team.name.label)).not.toBeDisabled()
+    await expect(page.getByLabel(t.team.name.label)).toHaveValue(firstTeamName)
+
+    // --- Users: view + manage ---
+    const usersLoadPromise = waitForApiCall(page, {
+      path: ADMIN_USERS_PATH,
+      status: HttpStatus.OK
+    })
+
+    await page.goto('/admin/users')
+    await usersLoadPromise
+
+    // Open the first user row
+    const firstUserRow = page.getByRole('row').nth(1)
+
+    const userDetailPromise = waitForApiCall(page, {
+      path: ADMIN_USER_PATH.replace(':userId', ''),
+      method: 'GET',
+      status: HttpStatus.OK
+    })
+
+    await firstUserRow.click()
+    await userDetailPromise
+
+    // View + manage permission: firstName and lastName fields must be editable
+    await expect(page.getByLabel(t.firstName.label)).not.toBeDisabled()
+    await expect(page.getByLabel(t.lastName.label)).not.toBeDisabled()
 
     await logOut(page, t)
   })


### PR DESCRIPTION
[Improvement]: Rename describe block to 'Invite admin with full access' — full access context lives at suite level
[Feature]: Validate accepted invite API response contains exactly the 4 default permissions (exact match, not subset)
[Feature]: Add test verifying invited admin can manage teams — Add button visible, name and description fields editable
[Feature]: Add test verifying invited admin can manage users — firstName and lastName fields editable