### PR TITLE
Add sidebar navigation E2E tests

### DIFF
--- a/.github/workflows/api-claude-code-review.yml
+++ b/.github/workflows/api-claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -38,12 +38,16 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Review this pull request (Bun + Hono + TypeScript API). Score each area 1–10. Be concise — one short justification per section, max 3 actionable issues if any.
+
+            If a previous review comment exists on this PR, use it as the baseline:
+            - Mark items that have been fixed since the last push with ~~strikethrough~~ and a ✅ suffix.
+            - Keep unresolved items and their scores as-is.
+            - Adjust scores and add new issues introduced by the latest push.
 
             Scoring criteria:
             - **🏗️ Architecture**: DRY, SOLID, modularity, low coupling. Adjust ±1 for data layer (schema, transactions, indexing) or infra (cache, queues, retries) if relevant.

--- a/.github/workflows/web-claude-code-review.yml
+++ b/.github/workflows/web-claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -42,12 +42,16 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request. It may touch one or more of: apps/web, apps/admin (Vite + React JS apps), packages/ui (shared React component library), or packages/i18n (i18n/translation resources — no components, focus on key naming and missing translations).
+
+            If a previous review comment exists on this PR, use it as the baseline:
+            - Mark items that have been fixed since the last push with ~~strikethrough~~ and a ✅ suffix.
+            - Keep unresolved items as-is.
+            - Add any new issues introduced by the latest push.
 
             Review areas:
             1. Code quality and best practices

--- a/apps/admin/e2e/navigation.spec.js
+++ b/apps/admin/e2e/navigation.spec.js
@@ -25,7 +25,10 @@ test.describe('Owner: Sidebar Navigation', () => {
     ]
 
     for (const { label, url } of items) {
-      await page.getByRole('button', { name: label }).click()
+      const item = page.getByRole('button', { name: label })
+
+      await expect(item).toBeVisible()
+      await item.click()
       await expect(page).toHaveURL(url)
     }
 
@@ -45,13 +48,20 @@ test.describe('Admin: Sidebar Navigation', () => {
     ]
 
     for (const { label, url } of items) {
-      await page.getByRole('button', { name: label }).click()
+      const item = page.getByRole('button', { name: label })
+
+      await expect(item).toBeVisible()
+      await item.click()
       await expect(page).toHaveURL(url)
     }
 
-    await expect(
-      page.getByRole('button', { name: t.sidebar.admins })
-    ).not.toBeVisible()
+    const forbiddenItems = [t.sidebar.admins]
+
+    for (const label of forbiddenItems) {
+      const item = page.getByRole('button', { name: label })
+
+      await expect(item).not.toBeVisible()
+    }
 
     await logOut(page, t)
   })

--- a/apps/admin/e2e/navigation.spec.js
+++ b/apps/admin/e2e/navigation.spec.js
@@ -1,0 +1,58 @@
+import { logOut } from '@smela/e2e/actions'
+
+import { expect, test } from './config/fixtures'
+
+const ownerCredentials = {
+  email: process.env.VITE_E2E_OWNER_EMAIL,
+  password: process.env.VITE_E2E_OWNER_PASSWORD
+}
+
+const adminCredentials = {
+  email: process.env.VITE_E2E_ADMIN_EMAIL,
+  password: process.env.VITE_E2E_ADMIN_PASSWORD
+}
+
+test.describe('Owner: Sidebar Navigation', () => {
+  test('navigates to all sidebar items', async ({ page, t, login }) => {
+    await login(ownerCredentials)
+
+    const items = [
+      { label: t.sidebar.dashboard, url: '/admin/dashboard' },
+      { label: t.sidebar.users, url: '/admin/users' },
+      { label: t.sidebar.teams, url: '/admin/teams' },
+      { label: t.sidebar.admins, url: '/owner/admins' },
+      { label: t.sidebar.settings, url: '/admin/settings' }
+    ]
+
+    for (const { label, url } of items) {
+      await page.getByRole('button', { name: label }).click()
+      await expect(page).toHaveURL(url)
+    }
+
+    await logOut(page, t)
+  })
+})
+
+test.describe('Admin: Sidebar Navigation', () => {
+  test('navigates to all sidebar items', async ({ page, t, login }) => {
+    await login(adminCredentials)
+
+    const items = [
+      { label: t.sidebar.dashboard, url: '/admin/dashboard' },
+      { label: t.sidebar.users, url: '/admin/users' },
+      { label: t.sidebar.teams, url: '/admin/teams' },
+      { label: t.sidebar.settings, url: '/admin/settings' }
+    ]
+
+    for (const { label, url } of items) {
+      await page.getByRole('button', { name: label }).click()
+      await expect(page).toHaveURL(url)
+    }
+
+    await expect(
+      page.getByRole('button', { name: t.sidebar.admins })
+    ).not.toBeVisible()
+
+    await logOut(page, t)
+  })
+})


### PR DESCRIPTION
[Feature]: Cover owner sidebar navigation — verifies all 5 items route to correct URLs
[Feature]: Cover admin sidebar navigation — verifies 4 accessible items and asserts Admins link not visible
[Improvement]: Add visibility assertions before clicks in E2E nav tests for better failure diagnostics
[Improvement]: Enable sticky review comments in CI workflows so Claude updates the same PR comment on each push