### PR TITLE
Add support admin seed user and env-based seed passwords

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -12,6 +12,7 @@ POSTGRES_DB=smela_back
 POSTGRES_MAX_CONNECTIONS=4
 
 SEED_USER_PASSWORD=your-seed-password # default password for seeded users
+SEED_USER_PASSWORD_HASH=your-bcrypt-hash # pre-computed bcrypt hash for fake user seeding
 
 # Network
 JWT_SECRET=your-secret-key-min-10-chars

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,6 +11,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB=smela_back
 POSTGRES_MAX_CONNECTIONS=4
 
+SEED_USER_PASSWORD=your-seed-password # default password for seeded users
+
 # Network
 JWT_SECRET=your-secret-key-min-10-chars
 # JWT_SECRET_PREVIOUS=your-previous-secret-key # optional, for secret rotation

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
     "db:init": "bun run db:generate && bun run db:migrate && bun run db:migrate:custom && bun run db:seed",
     "db:dev:up": "docker compose -f docker-compose-dev.yml --env-file .env.development up -d --wait",
     "db:dev:down": "docker compose -f docker-compose-dev.yml --env-file .env.development down -v",
-    "db:dev:reset": "bun run db:dev:down && bun run db:dev:up && NODE_ENV=development bun run db:init",
+    "db:dev:reset": "bun run db:dev:down && bun run db:dev:up && bun run db:init",
     "db:ui": "drizzle-kit studio",
     "format": "bunx prettier --check src",
     "format:fix": "bunx prettier --write src",

--- a/apps/api/src/data/scripts/seed-fake-users.ts
+++ b/apps/api/src/data/scripts/seed-fake-users.ts
@@ -35,9 +35,13 @@ import { authTable, usersTable } from '../schema'
 const BATCH_SIZE = 500
 const DEFAULT_COUNT = 5000
 
-// Pre-computed bcrypt hash for "FakeUser123!" to avoid slow hashing
-const DUMMY_PASSWORD_HASH =
-  '$2b$10$QKxGzLHk1BrFb7YrLsLnZuvEw3K.vUqhD4TxCPDdKFfqsHVqoA3lC'
+// Pre-computed bcrypt hash to avoid slow hashing
+const SEED_USER_PASSWORD_HASH = process.env['SEED_USER_PASSWORD_HASH']
+
+if (!SEED_USER_PASSWORD_HASH) {
+  console.error('❌ SEED_USER_PASSWORD_HASH is not set')
+  process.exit(1)
+}
 
 const NON_ALPHA_RE = /[^a-z]/g
 
@@ -90,7 +94,7 @@ const seedFakeUsers = async (count: number) => {
         userId: user.id,
         provider: AuthProvider.Local,
         identifier: users[j].email,
-        passwordHash: DUMMY_PASSWORD_HASH
+        passwordHash: SEED_USER_PASSWORD_HASH
       }))
 
       await tx.insert(authTable).values(authRecords)

--- a/apps/api/src/data/scripts/seed.ts
+++ b/apps/api/src/data/scripts/seed.ts
@@ -3,7 +3,7 @@
 /**
  * Seed initial data required to start the application
  *
- * Seeds: permissions, initial users (owner, admin, test users) with direct user permissions
+ * Seeds: permissions, initial users (owner, admin, support admin, test users) with direct user permissions
  *
  * Usage:
  *   bun run db:seed
@@ -28,6 +28,14 @@ import {
 
 // Seed faker for consistent data across runs
 faker.seed(42)
+
+// eslint-disable-next-line node/no-process-env
+const SEED_USER_PASSWORD = process.env['SEED_USER_PASSWORD']
+
+if (!SEED_USER_PASSWORD) {
+  console.error('❌ SEED_USER_PASSWORD is not set')
+  process.exit(1)
+}
 
 const seedPermissions = async () => {
   const allResources = Object.values(Resource)
@@ -151,7 +159,7 @@ const seedSystemUsers = async () => {
       firstName: 'Slava',
       lastName: 'Owner',
       email: 'owner@smela.me',
-      password: 'Passw0rd!',
+      password: SEED_USER_PASSWORD,
       role: Role.Owner,
       status: UserStatus.Active,
       permissions: [
@@ -164,12 +172,24 @@ const seedSystemUsers = async () => {
       firstName: 'Slava',
       lastName: 'Admin',
       email: 'admin@smela.me',
-      password: 'Passw0rd!',
+      password: SEED_USER_PASSWORD,
       role: Role.Admin,
       status: UserStatus.Active,
       permissions: [
         { action: Action.Manage, resource: Resource.Users },
         { action: Action.Manage, resource: Resource.Teams }
+      ]
+    },
+    {
+      firstName: 'Support',
+      lastName: 'Admin',
+      email: 'support@smela.me',
+      password: SEED_USER_PASSWORD,
+      role: Role.Admin,
+      status: UserStatus.Active,
+      permissions: [
+        { action: Action.View, resource: Resource.Users },
+        { action: Action.View, resource: Resource.Teams }
       ]
     }
   ]
@@ -222,7 +242,7 @@ const seedTestUsers = async (teamId: string) => {
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       email: 'alyce96@gmail.com', // Use a consistent email for testing
-      password: 'Passw0rd!',
+      password: SEED_USER_PASSWORD,
       status: UserStatus.Active,
       position: 'Developer',
       permissions: [
@@ -234,7 +254,7 @@ const seedTestUsers = async (teamId: string) => {
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       email: faker.internet.email().toLowerCase(),
-      password: 'Passw0rd!',
+      password: SEED_USER_PASSWORD,
       status: UserStatus.Pending,
       position: 'Designer',
       permissions: [


### PR DESCRIPTION
[Feature]: Add read-only support admin (`support@smela.me`) with `View` permissions on Users and Teams
[Security]: Replace hardcoded seed passwords with `SEED_USER_PASSWORD` env var — exits if unset
[Security]: Move fake user bcrypt hash to `SEED_USER_PASSWORD_HASH` env var in `seed-fake-users.ts`
[Improvement]: Remove redundant `NODE_ENV=development` from `db:dev:reset` script — Bun defaults to development
[Improvement]: Document new seed env vars in `.env.example`