### PR TITLE
Add read-only access for /admin/users and /admin/users/:id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@
 
 - When upgrading React, update the `version` field in
   `packages/eslint/src/react.js` → `settings.react.version`.
+- Keep comments general — describe intent, not current values or enumerated
+  items. Specific comments become stale when lists change and nobody remembers
+  to update them. Prefer `// Check hidden menu items` over
+  `// Invite and Remove actions must be hidden`.
 
 ## Skills
 

--- a/apps/admin/e2e/read-only-admin.spec.js
+++ b/apps/admin/e2e/read-only-admin.spec.js
@@ -1,11 +1,7 @@
 import { logOut } from '@smela/e2e/actions'
 import { waitForApiCall } from '@smela/e2e/api'
 import { HttpStatus } from '@smela/ui/lib/net'
-import {
-  ADMIN_TEAMS_PATH,
-  ME_PATH,
-  TEAMS_PATH
-} from '@smela/ui/services/backend/paths'
+import { ME_PATH } from '@smela/ui/services/backend/paths'
 
 import { expect, test } from './config/fixtures'
 
@@ -40,17 +36,73 @@ test.describe('Read-Only Admin: Authentication', () => {
   })
 })
 
+test.describe('Read-Only Admin: Users', () => {
+  test('User profile form fields are read-only and Save button is hidden', async ({
+    page,
+    t,
+    login
+  }) => {
+    await login(supportCredentials)
+
+    await page.goto('/admin/users')
+    await page.getByRole('row').nth(1).click()
+
+    await expect(page.getByLabel(t.firstName.label)).toHaveAttribute(
+      'readonly',
+      ''
+    )
+
+    await expect(page.getByLabel(t.lastName.label)).toHaveAttribute(
+      'readonly',
+      ''
+    )
+
+    await expect(page.getByRole('button', { name: t.save })).not.toBeVisible()
+
+    await logOut(page, t)
+  })
+
+  test('User membership form fields are read-only and Remove button is hidden', async ({
+    page,
+    t,
+    login
+  }) => {
+    await login(supportCredentials)
+
+    // Navigate via the team members list to get a user with a membership
+    await page.goto('/admin/teams')
+    await page.getByRole('searchbox', { name: 'Search' }).fill('Wisozk - Sipes')
+    await expect(page.getByRole('row')).toHaveCount(2) // header + 1 result
+    await page.getByRole('row').nth(1).click()
+    await page.getByRole('tab', { name: t.team.tabs.members.label }).click()
+
+    const memberRow = page.getByRole('row').nth(1)
+
+    await expect(memberRow).toBeVisible()
+    await memberRow.click()
+
+    await page.getByRole('tab', { name: t.membership }).click()
+
+    await expect(page.getByLabel(t.position.label)).toHaveAttribute(
+      'readonly',
+      ''
+    )
+
+    await expect(page.getByRole('button', { name: t.save })).not.toBeVisible()
+
+    await expect(
+      page.getByRole('button', { name: t.team.members.remove.cta })
+    ).not.toBeVisible()
+
+    await logOut(page, t)
+  })
+})
+
 test.describe('Read-Only Admin: Teams', () => {
   test('Add team button is not visible', async ({ page, t, login }) => {
     await login(supportCredentials)
 
-    const apiPromise = waitForApiCall(page, {
-      path: ADMIN_TEAMS_PATH,
-      status: HttpStatus.OK
-    })
-
     await page.goto('/admin/teams')
-    await apiPromise
 
     await expect(page.getByRole('button', { name: t.add })).not.toBeVisible()
 
@@ -64,27 +116,10 @@ test.describe('Read-Only Admin: Teams', () => {
   }) => {
     await login(supportCredentials)
 
-    const pageLoadPromise = waitForApiCall(page, {
-      path: ADMIN_TEAMS_PATH,
-      status: HttpStatus.OK
-    })
-
     await page.goto('/admin/teams')
-    await pageLoadPromise
-
     // Open first team row
-    const firstRow = page.getByRole('row').nth(1)
+    await page.getByRole('row').nth(1).click()
 
-    const detailPromise = waitForApiCall(page, {
-      path: TEAMS_PATH.replace(':teamId', ''),
-      method: 'GET',
-      status: HttpStatus.OK
-    })
-
-    await firstRow.click()
-    await detailPromise
-
-    // General tab: fields must be read-only (not editable), Save button hidden
     await expect(page.getByLabel(t.team.name.label)).toHaveAttribute(
       'readonly',
       ''

--- a/apps/admin/e2e/read-only-admin.spec.js
+++ b/apps/admin/e2e/read-only-admin.spec.js
@@ -57,6 +57,11 @@ test.describe('Read-Only Admin: Users', () => {
       ''
     )
 
+    await expect(page.getByLabel(t.status.name)).toHaveAttribute(
+      'aria-readonly',
+      'true'
+    )
+
     await expect(page.getByRole('button', { name: t.save })).not.toBeVisible()
 
     await logOut(page, t)

--- a/apps/admin/e2e/read-only-admin.spec.js
+++ b/apps/admin/e2e/read-only-admin.spec.js
@@ -10,6 +10,12 @@ const supportCredentials = {
   password: process.env.VITE_E2E_SUPPORT_PASSWORD
 }
 
+const searchAndOpen = async (page, query) => {
+  await page.getByRole('searchbox', { name: 'Search' }).fill(query)
+  await expect(page.getByRole('row')).toHaveCount(2) // header + 1 result
+  await page.getByRole('row').nth(1).click()
+}
+
 test.describe('Read-Only Admin: Authentication', () => {
   test('Login returns only view:teams and view:users permissions', async ({
     page,
@@ -53,15 +59,9 @@ test.describe('Read-Only Admin: Users', () => {
     await page.getByRole('row').nth(1).click()
 
     // Profile tab: fields must be read-only, Save button hidden
-    await expect(page.getByLabel(t.firstName.label)).toHaveAttribute(
-      'readonly',
-      ''
-    )
-
-    await expect(page.getByLabel(t.lastName.label)).toHaveAttribute(
-      'readonly',
-      ''
-    )
+    for (const label of [t.firstName.label, t.lastName.label]) {
+      await expect(page.getByLabel(label)).toHaveAttribute('readonly', '')
+    }
 
     await expect(page.getByLabel(t.status.name)).toHaveAttribute(
       'aria-readonly',
@@ -77,9 +77,7 @@ test.describe('Read-Only Admin: Users', () => {
   }) => {
     // Navigate via the team members list to get a user with a membership
     await page.goto('/admin/teams')
-    await page.getByRole('searchbox', { name: 'Search' }).fill('Wisozk - Sipes')
-    await expect(page.getByRole('row')).toHaveCount(2) // header + 1 result
-    await page.getByRole('row').nth(1).click()
+    await searchAndOpen(page, 'Wisozk - Sipes')
     await page.getByRole('tab', { name: t.team.tabs.members.label }).click()
 
     const memberRow = page.getByRole('row').nth(1)
@@ -127,20 +125,13 @@ test.describe('Read-Only Admin: Teams', () => {
     await page.getByRole('row').nth(1).click()
 
     // General tab: fields must be read-only, Save button hidden
-    await expect(page.getByLabel(t.team.name.label)).toHaveAttribute(
-      'readonly',
-      ''
-    )
-
-    await expect(page.getByLabel(t.team.website.label)).toHaveAttribute(
-      'readonly',
-      ''
-    )
-
-    await expect(page.getByLabel(t.team.description.label)).toHaveAttribute(
-      'readonly',
-      ''
-    )
+    for (const label of [
+      t.team.name.label,
+      t.team.website.label,
+      t.team.description.label
+    ]) {
+      await expect(page.getByLabel(label)).toHaveAttribute('readonly', '')
+    }
 
     await expect(page.getByRole('button', { name: t.save })).not.toBeVisible()
 
@@ -156,30 +147,24 @@ test.describe('Read-Only Admin: Teams', () => {
     t
   }) => {
     await page.goto('/admin/teams')
-
-    await page.getByRole('searchbox', { name: 'Search' }).fill('Wisozk - Sipes')
-    await expect(page.getByRole('row')).toHaveCount(2) // header + 1 result
-    await page.getByRole('row').nth(1).click()
+    await searchAndOpen(page, 'Wisozk - Sipes')
     await page.getByRole('tab', { name: t.team.tabs.members.label }).click()
 
     const memberRow = page.getByRole('row').nth(1)
 
     await expect(memberRow).toBeVisible()
-
     // Right-click first member row to open context menu
     await memberRow.click({ button: 'right' })
 
-    await expect(
-      page.getByRole('menuitem', { name: t.contextMenu.open })
-    ).toBeVisible()
+    // Check visible menu items
+    for (const name of [t.contextMenu.open]) {
+      await expect(page.getByRole('menuitem', { name })).toBeVisible()
+    }
 
-    await expect(
-      page.getByRole('menuitem', { name: t.contextMenu.invite })
-    ).not.toBeVisible()
-
-    await expect(
-      page.getByRole('menuitem', { name: t.contextMenu.remove })
-    ).not.toBeVisible()
+    // Check hidden menu items
+    for (const name of [t.contextMenu.invite, t.contextMenu.remove]) {
+      await expect(page.getByRole('menuitem', { name })).not.toBeVisible()
+    }
 
     // Close context menu
     await page.keyboard.press('Escape')

--- a/apps/admin/e2e/read-only-admin.spec.js
+++ b/apps/admin/e2e/read-only-admin.spec.js
@@ -37,16 +37,22 @@ test.describe('Read-Only Admin: Authentication', () => {
 })
 
 test.describe('Read-Only Admin: Users', () => {
+  test.beforeEach(async ({ login }) => {
+    await login(supportCredentials)
+  })
+
+  test.afterEach(async ({ page, t }) => {
+    await logOut(page, t)
+  })
+
   test('User profile form fields are read-only and Save button is hidden', async ({
     page,
-    t,
-    login
+    t
   }) => {
-    await login(supportCredentials)
-
     await page.goto('/admin/users')
     await page.getByRole('row').nth(1).click()
 
+    // Profile tab: fields must be read-only, Save button hidden
     await expect(page.getByLabel(t.firstName.label)).toHaveAttribute(
       'readonly',
       ''
@@ -63,17 +69,12 @@ test.describe('Read-Only Admin: Users', () => {
     )
 
     await expect(page.getByRole('button', { name: t.save })).not.toBeVisible()
-
-    await logOut(page, t)
   })
 
   test('User membership form fields are read-only and Remove button is hidden', async ({
     page,
-    t,
-    login
+    t
   }) => {
-    await login(supportCredentials)
-
     // Navigate via the team members list to get a user with a membership
     await page.goto('/admin/teams')
     await page.getByRole('searchbox', { name: 'Search' }).fill('Wisozk - Sipes')
@@ -88,6 +89,7 @@ test.describe('Read-Only Admin: Users', () => {
 
     await page.getByRole('tab', { name: t.membership }).click()
 
+    // Membership tab: Position field read-only, Save and Remove buttons hidden
     await expect(page.getByLabel(t.position.label)).toHaveAttribute(
       'readonly',
       ''
@@ -98,33 +100,33 @@ test.describe('Read-Only Admin: Users', () => {
     await expect(
       page.getByRole('button', { name: t.team.members.remove.cta })
     ).not.toBeVisible()
-
-    await logOut(page, t)
   })
 })
 
 test.describe('Read-Only Admin: Teams', () => {
-  test('Add team button is not visible', async ({ page, t, login }) => {
+  test.beforeEach(async ({ login }) => {
     await login(supportCredentials)
+  })
 
+  test.afterEach(async ({ page, t }) => {
+    await logOut(page, t)
+  })
+
+  test('Add team button is not visible', async ({ page, t }) => {
     await page.goto('/admin/teams')
 
     await expect(page.getByRole('button', { name: t.add })).not.toBeVisible()
-
-    await logOut(page, t)
   })
 
   test('Team general form fields are read-only and Invite button is hidden', async ({
     page,
-    t,
-    login
+    t
   }) => {
-    await login(supportCredentials)
-
     await page.goto('/admin/teams')
     // Open first team row
     await page.getByRole('row').nth(1).click()
 
+    // General tab: fields must be read-only, Save button hidden
     await expect(page.getByLabel(t.team.name.label)).toHaveAttribute(
       'readonly',
       ''
@@ -147,17 +149,12 @@ test.describe('Read-Only Admin: Teams', () => {
     await expect(
       page.getByRole('button', { name: t.invite.cta })
     ).not.toBeVisible()
-
-    await logOut(page, t)
   })
 
   test('Member row context menu shows only Open action', async ({
     page,
-    t,
-    login
+    t
   }) => {
-    await login(supportCredentials)
-
     await page.goto('/admin/teams')
 
     await page.getByRole('searchbox', { name: 'Search' }).fill('Wisozk - Sipes')
@@ -186,7 +183,5 @@ test.describe('Read-Only Admin: Teams', () => {
 
     // Close context menu
     await page.keyboard.press('Escape')
-
-    await logOut(page, t)
   })
 })

--- a/apps/admin/src/router.jsx
+++ b/apps/admin/src/router.jsx
@@ -66,8 +66,17 @@ export const router = createBrowserRouter([
     errorElement: <ErrorBoundary />,
     children: [
       { path: 'dashboard', element: <DashboardPage /> },
-      { path: 'users', element: <UsersPage /> },
-      { path: 'users/:id', element: <UserPage /> },
+      {
+        element: (
+          <PrivateRoute requirePermissions={['view:users']}>
+            <Outlet />
+          </PrivateRoute>
+        ),
+        children: [
+          { path: 'users', element: <UsersPage /> },
+          { path: 'users/:id', element: <UserPage /> }
+        ]
+      },
       {
         element: (
           <PrivateRoute requirePermissions={['view:teams']}>

--- a/packages/ui/src/components/UserStatus/StatusDropdown.jsx
+++ b/packages/ui/src/components/UserStatus/StatusDropdown.jsx
@@ -25,6 +25,7 @@ export const StatusDropdown = ({
         <Button
           id={id}
           variant='outline'
+          aria-readonly={readOnly || undefined}
           className={cn(
             'min-w-36 justify-between',
             readOnly && 'cursor-text select-text',

--- a/packages/ui/src/components/UserStatus/StatusDropdown.jsx
+++ b/packages/ui/src/components/UserStatus/StatusDropdown.jsx
@@ -12,28 +12,43 @@ import { cn } from '@ui/lib/utils'
 
 import { StatusBadge } from './StatusBadge'
 
-export const StatusDropdown = ({ className, value, onChange }) => (
+export const StatusDropdown = ({
+  id,
+  className,
+  value,
+  onChange,
+  readOnly
+}) => (
   <DropdownMenu>
     <DropdownMenuTrigger
       render={
         <Button
+          id={id}
           variant='outline'
-          className={cn('min-w-36 justify-between', className)}
+          className={cn(
+            'min-w-36 justify-between',
+            readOnly && 'cursor-text select-text',
+            className
+          )}
         />
       }
     >
       <StatusBadge status={value} />
-      <ChevronIcon className='group-aria-expanded/button:rotate-180' />
+      {!readOnly && (
+        <ChevronIcon className='group-aria-expanded/button:rotate-180' />
+      )}
     </DropdownMenuTrigger>
 
-    <DropdownMenuContent align='end' className='min-w-(--anchor-width)'>
-      <DropdownMenuRadioGroup value={value} onValueChange={onChange}>
-        {allUserStatuses.map(status => (
-          <DropdownMenuRadioItem key={status} value={status}>
-            <StatusBadge status={status} />
-          </DropdownMenuRadioItem>
-        ))}
-      </DropdownMenuRadioGroup>
-    </DropdownMenuContent>
+    {!readOnly && (
+      <DropdownMenuContent align='end' className='min-w-(--anchor-width)'>
+        <DropdownMenuRadioGroup value={value} onValueChange={onChange}>
+          {allUserStatuses.map(status => (
+            <DropdownMenuRadioItem key={status} value={status}>
+              <StatusBadge status={status} />
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    )}
   </DropdownMenu>
 )

--- a/packages/ui/src/components/form/FormController.jsx
+++ b/packages/ui/src/components/form/FormController.jsx
@@ -51,7 +51,7 @@ export const FormController = ({
           control={control}
           defaultValue={defaultValue}
           rules={rules}
-          render={({ field }) => render({ field, error })}
+          render={({ field }) => render({ field, error, id: name })}
         />
       </FormInputWrapper>
       {/* Always rendered for smooth enter/exit CSS transitions */}

--- a/packages/ui/src/components/form/FormController.jsx
+++ b/packages/ui/src/components/form/FormController.jsx
@@ -51,7 +51,7 @@ export const FormController = ({
           control={control}
           defaultValue={defaultValue}
           rules={rules}
-          render={({ field }) => render({ field, error, id: name })}
+          render={({ field }) => render({ id: name, field, error })}
         />
       </FormInputWrapper>
       {/* Always rendered for smooth enter/exit CSS transitions */}

--- a/packages/ui/src/components/form/MembershipForm/MembershipForm.jsx
+++ b/packages/ui/src/components/form/MembershipForm/MembershipForm.jsx
@@ -24,7 +24,8 @@ export const MembershipForm = ({
   team,
   teamLink,
   isSubmitting,
-  onSubmit
+  onSubmit,
+  readOnly = false
 }) => {
   const { t, formatDate } = useLocale()
 
@@ -60,7 +61,7 @@ export const MembershipForm = ({
             error={errors[FieldName.POSITION]}
             optional
           >
-            <Input {...register(FieldName.POSITION)} />
+            <Input {...register(FieldName.POSITION)} readOnly={readOnly} />
           </FormField>
         </FormRow>
 
@@ -76,9 +77,11 @@ export const MembershipForm = ({
           )}
         </FormRow>
 
-        <FormActions isDirty={isDirty}>
-          <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
-        </FormActions>
+        {!readOnly && (
+          <FormActions isDirty={isDirty}>
+            <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
+          </FormActions>
+        )}
       </FormFields>
     </FormRoot>
   )

--- a/packages/ui/src/components/form/UserInfoForm/UserInfoForm.jsx
+++ b/packages/ui/src/components/form/UserInfoForm/UserInfoForm.jsx
@@ -30,7 +30,8 @@ export const UserInfoForm = ({
   user,
   isSubmitting,
   onSubmit,
-  formFields = {}
+  formFields = {},
+  readOnly = false
 }) => {
   const fields = { ...defaultFields, ...formFields }
   const { t, formatDate } = useLocale()
@@ -64,7 +65,7 @@ export const UserInfoForm = ({
             name={FieldName.FIRST_NAME}
             error={errors[FieldName.FIRST_NAME]}
           >
-            <Input {...register(FieldName.FIRST_NAME)} />
+            <Input {...register(FieldName.FIRST_NAME)} readOnly={readOnly} />
           </FormField>
 
           <FormField
@@ -73,7 +74,7 @@ export const UserInfoForm = ({
             error={errors[FieldName.LAST_NAME]}
             optional
           >
-            <Input {...register(FieldName.LAST_NAME)} />
+            <Input {...register(FieldName.LAST_NAME)} readOnly={readOnly} />
           </FormField>
         </FormRow>
 
@@ -83,8 +84,13 @@ export const UserInfoForm = ({
               name={FieldName.STATUS}
               label={t('status.name')}
               control={control}
-              render={({ field }) => (
-                <StatusDropdown value={field.value} onChange={field.onChange} />
+              render={({ field, id }) => (
+                <StatusDropdown
+                  id={id}
+                  value={field.value}
+                  onChange={field.onChange}
+                  readOnly={readOnly}
+                />
               )}
             />
           </FormRow>
@@ -99,9 +105,11 @@ export const UserInfoForm = ({
           </FormField>
         </FormRow>
 
-        <FormActions isDirty={isDirty}>
-          <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
-        </FormActions>
+        {!readOnly && (
+          <FormActions isDirty={isDirty}>
+            <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
+          </FormActions>
+        )}
       </FormFields>
     </FormRoot>
   )

--- a/packages/ui/src/components/profile/MembershipSection.jsx
+++ b/packages/ui/src/components/profile/MembershipSection.jsx
@@ -12,7 +12,8 @@ export const MembershipSection = ({
   team,
   teamLink,
   update,
-  isUpdating
+  isUpdating,
+  readOnly = false
 }) => {
   const { t, te } = useLocale()
   const { user: me } = useCurrentUser()
@@ -37,8 +38,9 @@ export const MembershipSection = ({
         teamLink={teamLink}
         isSubmitting={isUpdating}
         onSubmit={handleUpdate}
+        readOnly={readOnly}
       />
-      {me?.id !== member?.id && (
+      {!readOnly && me?.id !== member?.id && (
         <>
           <TextSeparator />
           <RemoveMemberItem member={member} teamId={team?.id} />

--- a/packages/ui/src/components/profile/ProfileSection.jsx
+++ b/packages/ui/src/components/profile/ProfileSection.jsx
@@ -2,7 +2,13 @@ import { UserInfoForm } from '@ui/components/form'
 import { useLocale } from '@ui/hooks/useLocale'
 import { useToast } from '@ui/hooks/useToast'
 
-export const ProfileSection = ({ user, update, isUpdating, formFields }) => {
+export const ProfileSection = ({
+  user,
+  update,
+  isUpdating,
+  formFields,
+  readOnly = false
+}) => {
   const { t, te } = useLocale()
   const { showSuccessToast, showErrorToast } = useToast()
 
@@ -23,6 +29,7 @@ export const ProfileSection = ({ user, update, isUpdating, formFields }) => {
       isSubmitting={isUpdating}
       onSubmit={handleUpdate}
       formFields={formFields}
+      readOnly={readOnly}
     />
   )
 }

--- a/packages/ui/src/pages/admin/User/MembershipTab.jsx
+++ b/packages/ui/src/pages/admin/User/MembershipTab.jsx
@@ -1,7 +1,7 @@
 import { MembershipSection } from '@ui/components/profile'
 import { useTeamMember, useUpdateTeamMember } from '@ui/hooks/useTeam'
 
-export const MembershipTab = ({ user, team }) => {
+export const MembershipTab = ({ user, team, readOnly = false }) => {
   const { data: member } = useTeamMember(team.id, user.id)
   const { mutate, isPending: isUpdating } = useUpdateTeamMember(
     team.id,
@@ -16,6 +16,7 @@ export const MembershipTab = ({ user, team }) => {
       teamLink={`/admin/teams/${team.id}`}
       update={update}
       isUpdating={isUpdating}
+      readOnly={readOnly}
     />
   )
 }

--- a/packages/ui/src/pages/admin/User/ProfileTab.jsx
+++ b/packages/ui/src/pages/admin/User/ProfileTab.jsx
@@ -1,8 +1,15 @@
 import { ProfileSection } from '@ui/components/profile'
 import { useUpdateUser } from '@ui/hooks/useAdmin'
 
-export const ProfileTab = ({ user }) => {
+export const ProfileTab = ({ user, readOnly = false }) => {
   const { mutate, isPending } = useUpdateUser(user.id)
 
-  return <ProfileSection user={user} update={mutate} isUpdating={isPending} />
+  return (
+    <ProfileSection
+      user={user}
+      update={mutate}
+      isUpdating={isPending}
+      readOnly={readOnly}
+    />
+  )
 }

--- a/packages/ui/src/pages/admin/User/UserPage.jsx
+++ b/packages/ui/src/pages/admin/User/UserPage.jsx
@@ -10,6 +10,7 @@ import { Spinner } from '@ui/components/Spinner'
 import { ErrorState } from '@ui/components/states'
 import { Tabs, TabsContent, TabsLine } from '@ui/components/ui'
 import { useUser } from '@ui/hooks/useAdmin'
+import { useCurrentUser } from '@ui/hooks/useAuth'
 import { useHashTab } from '@ui/hooks/useHashTab'
 import { useLocale } from '@ui/hooks/useLocale'
 import { useLocation, useParams } from '@ui/hooks/useRouter'
@@ -21,6 +22,8 @@ export const UserPage = () => {
   const { id } = useParams()
   const { state } = useLocation()
   const { t } = useLocale()
+  const { can } = useCurrentUser()
+
   const {
     data: user,
     isPending,
@@ -36,6 +39,8 @@ export const UserPage = () => {
     getUserTabValues(hasMembership),
     Tab.PROFILE
   )
+
+  const readOnly = !can('manage:users')
 
   if (isError) {
     return <ErrorState error={error} onRetry={refetch} />
@@ -54,11 +59,11 @@ export const UserPage = () => {
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsLine tabs={getUserTabs(hasMembership, t)} />
         <TabsContent value={Tab.PROFILE}>
-          <ProfileTab user={user} />
+          <ProfileTab user={user} readOnly={readOnly} />
         </TabsContent>
         {hasMembership && (
           <TabsContent value={Tab.MEMBERSHIP}>
-            <MembershipTab user={user} team={user?.team} />
+            <MembershipTab user={user} team={user?.team} readOnly={readOnly} />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
[Feature]: Guard /admin/users routes with view:users permission via PrivateRoute
[Feature]: Derive readOnly from manage:users permission in UserPage, thread to ProfileTab and MembershipTab
[Feature]: Make UserInfoForm fields read-only and hide Save button for view-only admins
[Feature]: Make MembershipForm Position field read-only, hide Save and Remove buttons for view-only admins
[Fix]: Fix label-to-focus wiring for FormController fields by passing id into render callback
[Improvement]: Add readOnly and aria-readonly support to StatusDropdown with select-text cursor
[Improvement]: Simplify E2E spec with beforeEach/afterEach, loops, and shared helper to reduce duplication