### PR TITLE
Fix error pages to hard reload on home navigation

### DIFF
--- a/packages/ui/src/pages/errors/Forbidden/ForbiddenErrorPage.jsx
+++ b/packages/ui/src/pages/errors/Forbidden/ForbiddenErrorPage.jsx
@@ -1,5 +1,4 @@
 import { useLocale } from '@ui/hooks/useLocale'
-import { useNavigate } from '@ui/hooks/useRouter'
 import { ShieldX } from 'lucide-react'
 
 import {
@@ -13,7 +12,6 @@ import {
 
 export const ForbiddenErrorPage = () => {
   const { t } = useLocale()
-  const navigate = useNavigate()
 
   return (
     <ErrorRoot data-testid='forbidden-error-page'>
@@ -22,7 +20,7 @@ export const ForbiddenErrorPage = () => {
         <ErrorTitle>{t('error.forbidden.title')}</ErrorTitle>
         <ErrorDescription>{t('error.forbidden.message')}</ErrorDescription>
       </ErrorContent>
-      <ErrorButton onClick={() => navigate('/')}>
+      <ErrorButton onClick={() => (window.location.href = '/')}>
         {t('error.forbidden.cta')}
       </ErrorButton>
     </ErrorRoot>

--- a/packages/ui/src/pages/errors/Forbidden/__tests__/Forbidden.test.jsx
+++ b/packages/ui/src/pages/errors/Forbidden/__tests__/Forbidden.test.jsx
@@ -8,10 +8,6 @@ const en = resources.en.translation
 import { ForbiddenErrorPage } from '../index'
 
 describe('ForbiddenErrorPage', () => {
-  beforeEach(() => {
-    globalThis.mockNavigate.mockClear()
-  })
-
   it('renders title, message, and button', () => {
     renderWithProviders(<ForbiddenErrorPage />)
 
@@ -28,7 +24,7 @@ describe('ForbiddenErrorPage', () => {
     ).toBeVisible()
   })
 
-  it('navigates to home when button is clicked', async () => {
+  it('hard reloads to home when button is clicked', async () => {
     const user = userEvent.setup()
 
     renderWithProviders(<ForbiddenErrorPage />)
@@ -37,7 +33,6 @@ describe('ForbiddenErrorPage', () => {
       screen.getByRole('button', { name: en.error.forbidden.cta })
     )
 
-    expect(globalThis.mockNavigate).toHaveBeenCalledWith('/')
-    expect(globalThis.mockNavigate).toHaveBeenCalledTimes(1)
+    expect(window.location.href).toBe('http://localhost:3000/')
   })
 })

--- a/packages/ui/src/pages/errors/General/GeneralErrorPage.jsx
+++ b/packages/ui/src/pages/errors/General/GeneralErrorPage.jsx
@@ -1,5 +1,4 @@
 import { useLocale } from '@ui/hooks/useLocale'
-import { useNavigate } from '@ui/hooks/useRouter'
 import { ServerCrash } from 'lucide-react'
 
 import {
@@ -13,7 +12,6 @@ import {
 
 export const GeneralErrorPage = () => {
   const { t } = useLocale()
-  const navigate = useNavigate()
 
   return (
     <ErrorRoot data-testid='general-error-page'>
@@ -22,7 +20,7 @@ export const GeneralErrorPage = () => {
         <ErrorTitle>{t('error.general.title')}</ErrorTitle>
         <ErrorDescription>{t('error.general.message')}</ErrorDescription>
       </ErrorContent>
-      <ErrorButton onClick={() => navigate('/')}>
+      <ErrorButton onClick={() => (window.location.href = '/')}>
         {t('error.general.cta')}
       </ErrorButton>
     </ErrorRoot>

--- a/packages/ui/src/pages/errors/General/__tests__/General.test.jsx
+++ b/packages/ui/src/pages/errors/General/__tests__/General.test.jsx
@@ -7,10 +7,6 @@ const en = resources.en.translation
 import { GeneralErrorPage } from '../index'
 
 describe('GeneralErrorPage', () => {
-  beforeEach(() => {
-    globalThis.mockNavigate.mockClear()
-  })
-
   it('renders error icon, title, message, and button', () => {
     renderWithProviders(<GeneralErrorPage />)
 
@@ -27,14 +23,13 @@ describe('GeneralErrorPage', () => {
     ).toBeVisible()
   })
 
-  it('navigates to home when button is clicked', async () => {
+  it('hard reloads to home when button is clicked', async () => {
     const user = userEvent.setup()
 
     renderWithProviders(<GeneralErrorPage />)
 
     await user.click(screen.getByRole('button', { name: en.error.general.cta }))
 
-    expect(globalThis.mockNavigate).toHaveBeenCalledWith('/')
-    expect(globalThis.mockNavigate).toHaveBeenCalledTimes(1)
+    expect(window.location.href).toBe('http://localhost:3000/')
   })
 })

--- a/packages/ui/src/pages/errors/NotFound/NotFoundErrorPage.jsx
+++ b/packages/ui/src/pages/errors/NotFound/NotFoundErrorPage.jsx
@@ -1,5 +1,5 @@
 import { useLocale } from '@ui/hooks/useLocale'
-import { useLocation, useNavigate } from '@ui/hooks/useRouter'
+import { useLocation } from '@ui/hooks/useRouter'
 import { captureMessage } from '@ui/services/errorTracker'
 import { SearchX } from 'lucide-react'
 import { useEffect } from 'react'
@@ -15,7 +15,6 @@ import {
 
 export const NotFoundErrorPage = () => {
   const { t } = useLocale()
-  const navigate = useNavigate()
   const location = useLocation()
 
   useEffect(() => {
@@ -29,7 +28,7 @@ export const NotFoundErrorPage = () => {
         <ErrorTitle>{t('error.notFound.title')}</ErrorTitle>
         <ErrorDescription>{t('error.notFound.message')}</ErrorDescription>
       </ErrorContent>
-      <ErrorButton onClick={() => navigate('/')}>
+      <ErrorButton onClick={() => (window.location.href = '/')}>
         {t('error.notFound.cta')}
       </ErrorButton>
     </ErrorRoot>

--- a/packages/ui/src/pages/errors/NotFound/__tests__/NotFound.test.jsx
+++ b/packages/ui/src/pages/errors/NotFound/__tests__/NotFound.test.jsx
@@ -9,7 +9,6 @@ import { NotFoundErrorPage } from '../index'
 
 describe('NotFoundErrorPage', () => {
   beforeEach(() => {
-    globalThis.mockNavigate.mockClear()
     captureMessage.mockClear()
   })
 
@@ -29,7 +28,7 @@ describe('NotFoundErrorPage', () => {
     ).toBeVisible()
   })
 
-  it('navigates to home when button is clicked', async () => {
+  it('hard reloads to home when button is clicked', async () => {
     const user = userEvent.setup()
 
     renderWithProviders(<NotFoundErrorPage />)
@@ -38,8 +37,7 @@ describe('NotFoundErrorPage', () => {
       screen.getByRole('button', { name: en.error.notFound.cta })
     )
 
-    expect(globalThis.mockNavigate).toHaveBeenCalledWith('/')
-    expect(globalThis.mockNavigate).toHaveBeenCalledTimes(1)
+    expect(window.location.href).toBe('http://localhost:3000/')
   })
 
   it('reports 404 to error tracker on mount', () => {


### PR DESCRIPTION
[Fix]: Replace `navigate('/')` with `window.location.href = '/'` on General, Forbidden, and NotFound error pages to force a full page reload and reset all React context after an error

[Fix]: Update tests to assert `window.location.href` instead of the mocked router's navigate function