### PR TITLE
Remove /admin route prefix from admin app

### DIFF
--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -63,7 +63,7 @@ Routes are defined in `/src/routes/router.jsx` with admin-focused organization:
 | ------------- | -------------- | -------------------------------------------- |
 | Root          | None           | `/` (redirect to login or admin)             |
 | `AuthLayout`  | `PublicRoute`  | `/login`, `/signup`, `/reset-password`, etc. |
-| `UserLayout`  | `PrivateRoute` | `/admin/*` (admin), `/owner/*` (owner)       |
+| `UserLayout`  | `PrivateRoute` | `/dashboard`, `/users/*`, `/teams/*`, etc. (admin), `/owner/*` (owner) |
 | `ErrorLayout` | None           | `/errors/*`, `*` (404)                       |
 
 Route guards:

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -59,12 +59,12 @@ The app uses React Context API for global state:
 
 Routes are defined in `/src/routes/router.jsx` with admin-focused organization:
 
-| Layout        | Guard          | Routes                                       |
-| ------------- | -------------- | -------------------------------------------- |
-| Root          | None           | `/` (redirect to login or admin)             |
-| `AuthLayout`  | `PublicRoute`  | `/login`, `/signup`, `/reset-password`, etc. |
+| Layout        | Guard          | Routes                                                                 |
+| ------------- | -------------- | ---------------------------------------------------------------------- |
+| Root          | None           | `/` (redirect to login or admin)                                       |
+| `AuthLayout`  | `PublicRoute`  | `/login`, `/signup`, `/reset-password`, etc.                           |
 | `UserLayout`  | `PrivateRoute` | `/dashboard`, `/users/*`, `/teams/*`, etc. (admin), `/owner/*` (owner) |
-| `ErrorLayout` | None           | `/errors/*`, `*` (404)                       |
+| `ErrorLayout` | None           | `/errors/*`, `*` (404)                                                 |
 
 Route guards:
 

--- a/apps/admin/e2e/admin-teams-management.spec.js
+++ b/apps/admin/e2e/admin-teams-management.spec.js
@@ -40,7 +40,7 @@ test.describe.serial('Admin: Teams Management', () => {
         )
     })
 
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
     await pageLoadPromise
 
     // Open Add Team dialog
@@ -82,7 +82,7 @@ test.describe.serial('Admin: Teams Management', () => {
       status: HttpStatus.OK
     })
 
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
     await pageLoadPromise
 
     // Click on the team row to open details, wait for team detail to load
@@ -140,7 +140,7 @@ test.describe.serial('Admin: Teams Management', () => {
       status: HttpStatus.OK
     })
 
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
     await pageLoadPromise
 
     // Open the team
@@ -178,7 +178,7 @@ test.describe('Admin: Teams Edge Cases', () => {
       })
     })
 
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
 
     // Verify table header is visible but no data rows
     await expect(page.getByRole('table')).toBeVisible()
@@ -199,7 +199,7 @@ test.describe('Admin: Teams Edge Cases', () => {
       })
     })
 
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
 
     // Verify error state
     await expect(

--- a/apps/admin/e2e/navigation.spec.js
+++ b/apps/admin/e2e/navigation.spec.js
@@ -17,11 +17,11 @@ test.describe('Owner: Sidebar Navigation', () => {
     await login(ownerCredentials)
 
     const items = [
-      { label: t.sidebar.dashboard, url: '/admin/dashboard' },
-      { label: t.sidebar.users, url: '/admin/users' },
-      { label: t.sidebar.teams, url: '/admin/teams' },
+      { label: t.sidebar.dashboard, url: '/dashboard' },
+      { label: t.sidebar.users, url: '/users' },
+      { label: t.sidebar.teams, url: '/teams' },
       { label: t.sidebar.admins, url: '/owner/admins' },
-      { label: t.sidebar.settings, url: '/admin/settings' }
+      { label: t.sidebar.settings, url: '/settings' }
     ]
 
     for (const { label, url } of items) {
@@ -41,10 +41,10 @@ test.describe('Admin: Sidebar Navigation', () => {
     await login(adminCredentials)
 
     const items = [
-      { label: t.sidebar.dashboard, url: '/admin/dashboard' },
-      { label: t.sidebar.users, url: '/admin/users' },
-      { label: t.sidebar.teams, url: '/admin/teams' },
-      { label: t.sidebar.settings, url: '/admin/settings' }
+      { label: t.sidebar.dashboard, url: '/dashboard' },
+      { label: t.sidebar.users, url: '/users' },
+      { label: t.sidebar.teams, url: '/teams' },
+      { label: t.sidebar.settings, url: '/settings' }
     ]
 
     for (const { label, url } of items) {

--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -194,7 +194,7 @@ test.describe.serial('Owner: Invite admin with full access', () => {
     // Verify success toast
     await expect(page.getByText(t.invite.accept.success)).toBeVisible()
 
-    await page.waitForURL('/admin/dashboard')
+    await page.waitForURL('/dashboard')
 
     await logOut(page, t)
   })
@@ -206,7 +206,7 @@ test.describe.serial('Owner: Invite admin with full access', () => {
   }) => {
     await login({ email: newAdmin.email, password: newAdmin.password })
 
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
 
     // Manage permission: Add button must be visible
     await expect(page.getByRole('button', { name: t.add })).toBeVisible()
@@ -228,7 +228,7 @@ test.describe.serial('Owner: Invite admin with full access', () => {
   }) => {
     await login({ email: newAdmin.email, password: newAdmin.password })
 
-    await page.goto('/admin/users')
+    await page.goto('/users')
 
     // Open the first user row
     await page.getByRole('row').nth(1).click()

--- a/apps/admin/e2e/read-only-admin.spec.js
+++ b/apps/admin/e2e/read-only-admin.spec.js
@@ -55,7 +55,7 @@ test.describe('Read-Only Admin: Users', () => {
     page,
     t
   }) => {
-    await page.goto('/admin/users')
+    await page.goto('/users')
     await page.getByRole('row').nth(1).click()
 
     // Profile tab: fields must be read-only, Save button hidden
@@ -76,7 +76,7 @@ test.describe('Read-Only Admin: Users', () => {
     t
   }) => {
     // Navigate via the team members list to get a user with a membership
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
     await searchAndOpen(page, 'Wisozk - Sipes')
     await page.getByRole('tab', { name: t.team.tabs.members.label }).click()
 
@@ -111,7 +111,7 @@ test.describe('Read-Only Admin: Teams', () => {
   })
 
   test('Add team button is not visible', async ({ page, t }) => {
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
 
     await expect(page.getByRole('button', { name: t.add })).not.toBeVisible()
   })
@@ -120,7 +120,7 @@ test.describe('Read-Only Admin: Teams', () => {
     page,
     t
   }) => {
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
     // Open first team row
     await page.getByRole('row').nth(1).click()
 
@@ -146,7 +146,7 @@ test.describe('Read-Only Admin: Teams', () => {
     page,
     t
   }) => {
-    await page.goto('/admin/teams')
+    await page.goto('/teams')
     await searchAndOpen(page, 'Wisozk - Sipes')
     await page.getByRole('tab', { name: t.team.tabs.members.label }).click()
 

--- a/apps/admin/src/router.jsx
+++ b/apps/admin/src/router.jsx
@@ -14,6 +14,7 @@ import {
   ResetPasswordPage
 } from '@smela/ui/pages/auth'
 import {
+  ForbiddenErrorPage,
   GeneralErrorPage,
   NetworkErrorPage,
   NotFoundErrorPage
@@ -30,8 +31,8 @@ import { createBrowserRouter, Outlet } from 'react-router-dom'
 
 export const router = createBrowserRouter([
   {
-    element: <RootRedirect />,
-    path: '/'
+    errorElement: <ErrorBoundary />,
+    children: [{ path: '/', element: <RootRedirect /> }]
   },
   {
     element: (
@@ -54,7 +55,7 @@ export const router = createBrowserRouter([
     ]
   },
   {
-    path: '/admin',
+    path: '/',
     element: (
       <PrivateRoute
         requireStatuses={adminActiveStatuses}
@@ -112,6 +113,7 @@ export const router = createBrowserRouter([
     path: 'errors',
     element: <ErrorLayout />,
     children: [
+      { path: 'forbidden', element: <ForbiddenErrorPage /> },
       { path: 'general', element: <GeneralErrorPage /> },
       { path: 'network', element: <NetworkErrorPage /> }
     ]

--- a/apps/api/src/emails/templates/user-invitation.tsx
+++ b/apps/api/src/emails/templates/user-invitation.tsx
@@ -58,7 +58,7 @@ const UserInvitationEmail = ({
 UserInvitationEmail.PreviewProps = {
   data: {
     firstName: 'Jason',
-    inviteUrl: `http://localhost:5173/auth/accept-invite?token=eb6a0c90a8e75d4c9d5a93def2911d7b`,
+    inviteUrl: `http://localhost:5173/accept-invite?token=eb6a0c90a8e75d4c9d5a93def2911d7b`,
     inviterName: 'Alice',
     teamName: 'Acme Inc'
   },

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -65,7 +65,7 @@ Routes are defined in `/src/routes/router.jsx` with layout-based organization:
 | `PublicLayout` | None           | `/` (redirect), `/pricing`                   |
 | `AuthLayout`   | `PublicRoute`  | `/login`, `/signup`, `/reset-password`, etc. |
 | `LegalLayout`  | None           | `/terms`, `/privacy`                         |
-| `UserLayout`   | `PrivateRoute` | `/home` (user), `/admin/*` (admin)           |
+| `UserLayout`   | `PrivateRoute` | `/home`, `/team/*`, `/profile`, `/settings`  |
 | `ErrorLayout`  | None           | `/errors/*`, `*` (404)                       |
 
 Route guards:

--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -542,7 +542,7 @@ test.describe('Authentication: General', () => {
 
     await page.waitForURL('/home')
 
-    const unauthorizedPaths = ['/unknown', '/admin/users', '/owner/admins']
+    const unauthorizedPaths = ['/unknown', '/owner/admins']
 
     for (const path of unauthorizedPaths) {
       await page.goto(path)

--- a/apps/web/src/router.jsx
+++ b/apps/web/src/router.jsx
@@ -16,6 +16,7 @@ import {
   VerifyEmailPage
 } from '@smela/ui/pages/auth'
 import {
+  ForbiddenErrorPage,
   GeneralErrorPage,
   NetworkErrorPage,
   NotFoundErrorPage
@@ -101,6 +102,7 @@ export const router = createBrowserRouter([
     path: 'errors',
     element: <ErrorLayout />,
     children: [
+      { path: 'forbidden', element: <ForbiddenErrorPage /> },
       { path: 'general', element: <GeneralErrorPage /> },
       { path: 'network', element: <NetworkErrorPage /> }
     ]

--- a/packages/ui/src/components/Header/UserProfileDropdown.jsx
+++ b/packages/ui/src/components/Header/UserProfileDropdown.jsx
@@ -7,7 +7,7 @@ import { ProfileDropdown } from './ProfileDropdown'
 
 const getProfilePath = role => {
   if (isAdmin(role)) {
-    return '/admin/profile'
+    return '/profile'
   }
 
   return '/profile'

--- a/packages/ui/src/components/Header/UserProfileDropdown.jsx
+++ b/packages/ui/src/components/Header/UserProfileDropdown.jsx
@@ -1,17 +1,8 @@
 import { useLogout } from '@ui/hooks/useAuth'
 import { useNavigate } from '@ui/hooks/useRouter'
-import { isAdmin } from '@ui/lib/types'
 import { LogOut, MessageCircleQuestion, User } from 'lucide-react'
 
 import { ProfileDropdown } from './ProfileDropdown'
-
-const getProfilePath = role => {
-  if (isAdmin(role)) {
-    return '/profile'
-  }
-
-  return '/profile'
-}
 
 export const UserProfileDropdown = ({ user }) => {
   const navigate = useNavigate()
@@ -30,7 +21,7 @@ export const UserProfileDropdown = ({ user }) => {
       label: 'profile.title',
       icon: <User className='size-4' />,
       onClick: () => {
-        navigate(getProfilePath(user?.role))
+        navigate('/profile')
       }
     },
     {

--- a/packages/ui/src/components/Sidebar/menu.js
+++ b/packages/ui/src/components/Sidebar/menu.js
@@ -43,23 +43,23 @@ export const getAdminMenuItems = ({
 } = {}) => [
   {
     title: 'sidebar.dashboard',
-    url: '/admin/dashboard',
+    url: '/dashboard',
     icon: LayoutDashboard
   },
   {
     title: 'sidebar.users',
-    url: '/admin/users',
+    url: '/users',
     icon: User
   },
   ...(canViewTeams
-    ? [{ title: 'sidebar.teams', url: '/admin/teams', icon: Users }]
+    ? [{ title: 'sidebar.teams', url: '/teams', icon: Users }]
     : []),
   ...(canViewAdmins
     ? [{ title: 'sidebar.admins', url: '/owner/admins', icon: ShieldCheck }]
     : []),
   {
     title: 'sidebar.settings',
-    url: '/admin/settings',
+    url: '/settings',
     icon: Settings
   }
 ]

--- a/packages/ui/src/hooks/__tests__/useHashTab.test.js
+++ b/packages/ui/src/hooks/__tests__/useHashTab.test.js
@@ -56,7 +56,7 @@ describe('useHashTab', () => {
   })
 
   it('preserves pathname when setting new hash', () => {
-    mockLocation = { pathname: '/admin/users', search: '', hash: '#tab1' }
+    mockLocation = { pathname: '/users', search: '', hash: '#tab1' }
     const { result } = renderHook(() => useHashTab(validValues, defaultValue))
 
     act(() => {
@@ -64,7 +64,7 @@ describe('useHashTab', () => {
     })
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      { pathname: '/admin/users', search: '', hash: '#tab2' },
+      { pathname: '/users', search: '', hash: '#tab2' },
       { replace: true }
     )
   })
@@ -85,7 +85,7 @@ describe('useHashTab', () => {
 
   it('preserves both pathname and search when setting new hash', () => {
     mockLocation = {
-      pathname: '/admin/teams',
+      pathname: '/teams',
       search: '?filter=active',
       hash: '#tab1'
     }
@@ -97,7 +97,7 @@ describe('useHashTab', () => {
     })
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      { pathname: '/admin/teams', search: '?filter=active', hash: '#tab3' },
+      { pathname: '/teams', search: '?filter=active', hash: '#tab3' },
       { replace: true }
     )
   })

--- a/packages/ui/src/pages/admin/Team/TeamPage.jsx
+++ b/packages/ui/src/pages/admin/Team/TeamPage.jsx
@@ -63,7 +63,7 @@ export const TeamPage = () => {
             teamId={teamId}
             readOnly={readOnly}
             onRowClick={member =>
-              navigate(`/admin/users/${member.id}`, { state: { user: member } })
+              navigate(`/users/${member.id}`, { state: { user: member } })
             }
           />
         </TabsContent>

--- a/packages/ui/src/pages/admin/Teams/TeamsPage.jsx
+++ b/packages/ui/src/pages/admin/Teams/TeamsPage.jsx
@@ -49,8 +49,7 @@ export const TeamsPage = () => {
   )
   const [sorting, setSorting] = useState([])
 
-  const viewTeam = team =>
-    navigate(`/admin/teams/${team.id}`, { state: { team } })
+  const viewTeam = team => navigate(`/teams/${team.id}`, { state: { team } })
 
   const contextMenu = [createOpenItem(t, viewTeam, Users)]
 

--- a/packages/ui/src/pages/admin/User/MembershipTab.jsx
+++ b/packages/ui/src/pages/admin/User/MembershipTab.jsx
@@ -13,7 +13,7 @@ export const MembershipTab = ({ user, team, readOnly = false }) => {
     <MembershipSection
       member={member}
       team={team}
-      teamLink={`/admin/teams/${team.id}`}
+      teamLink={`/teams/${team.id}`}
       update={update}
       isUpdating={isUpdating}
       readOnly={readOnly}

--- a/packages/ui/src/pages/admin/Users/UsersPage.jsx
+++ b/packages/ui/src/pages/admin/Users/UsersPage.jsx
@@ -45,7 +45,7 @@ export const UsersPage = () => {
   const toggleFilters = () => setShowFilters(prev => !prev)
 
   const openUserProfile = user =>
-    navigate(`/admin/users/${user.id}`, { state: { user } })
+    navigate(`/users/${user.id}`, { state: { user } })
 
   const contextMenu = [createOpenItem(t, openUserProfile)]
 

--- a/packages/ui/src/routes/RootRedirect.jsx
+++ b/packages/ui/src/routes/RootRedirect.jsx
@@ -41,7 +41,7 @@ export const RootRedirect = () => {
     isAdmin(role) &&
     adminActiveStatuses.includes(status)
   ) {
-    return <Navigate to='/admin/dashboard' replace />
+    return <Navigate to='/dashboard' replace />
   }
 
   return <Navigate to='/login' replace />


### PR DESCRIPTION
## Changes

[Improvement]: Drop redundant `/admin` URL prefix — `apps/admin` is a standalone app so the prefix adds no value
[Improvement]: Update all navigation links, menu URLs, and page redirects to use prefixless routes
[Improvement]: Add `errors/forbidden` route to both `apps/admin` and `apps/web` routers for direct navigability
[Fix]: Resolve duplicate `path: '/'` in admin router by wrapping `RootRedirect` in a pathless parent
[Fix]: Correct stale `/auth/accept-invite` path in email template preview props
[Fix]: Remove `getProfilePath` helper that always returned the same value (Sonar)
[Improvement]: Update CLAUDE.md routing tables in both apps to reflect actual routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)