### PR TITLE
Fix jsconfig paths to use @smela/* package names

### DIFF
--- a/apps/admin/jsconfig.json
+++ b/apps/admin/jsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
-      "@ui/*": ["../../packages/ui/src/*"]
+      "@smela/ui/*": ["../../packages/ui/src/*"],
+      "@smela/i18n": ["../../packages/i18n/src/index.js"]
     }
   },
   "include": ["src"]

--- a/apps/web/jsconfig.json
+++ b/apps/web/jsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
-      "@ui/*": ["../../packages/ui/src/*"]
+      "@smela/ui/*": ["../../packages/ui/src/*"],
+      "@smela/i18n": ["../../packages/i18n/src/index.js"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
[Fix]: Replace \`@ui/*\` path alias with \`@smela/ui/*\` to match actual import namespace used across all source files
[Fix]: Add \`@smela/i18n\` path mapping so language service resolves the i18n package without warnings