### PR TITLE
Flatten /owner/admins routes and add permission guards

### DIFF
--- a/apps/admin/e2e/navigation.spec.js
+++ b/apps/admin/e2e/navigation.spec.js
@@ -20,7 +20,7 @@ test.describe('Owner: Sidebar Navigation', () => {
       { label: t.sidebar.dashboard, url: '/dashboard' },
       { label: t.sidebar.users, url: '/users' },
       { label: t.sidebar.teams, url: '/teams' },
-      { label: t.sidebar.admins, url: '/owner/admins' },
+      { label: t.sidebar.admins, url: '/admins' },
       { label: t.sidebar.settings, url: '/settings' }
     ]
 

--- a/apps/admin/e2e/owner-admins-management.spec.js
+++ b/apps/admin/e2e/owner-admins-management.spec.js
@@ -34,7 +34,7 @@ test.describe('Owner: Admins Page', () => {
       status: HttpStatus.OK
     })
 
-    await page.goto('/owner/admins')
+    await page.goto('/admins')
     await apiPromise
 
     const columnsButton = page.getByRole('button', {
@@ -88,7 +88,7 @@ test.describe('Owner: Admins Page', () => {
       status: HttpStatus.OK
     })
 
-    await page.goto('/owner/admins')
+    await page.goto('/admins')
     await apiPromise
 
     const searchInput = page.getByRole('searchbox', { name: 'Search' })
@@ -120,7 +120,7 @@ test.describe.serial('Owner: Invite admin with full access', () => {
       status: HttpStatus.OK
     })
 
-    await page.goto('/owner/admins')
+    await page.goto('/admins')
     await apiPromise
 
     // Click Invite button to open modal
@@ -252,7 +252,7 @@ test.describe.serial('Owner: Invite admin with full access', () => {
       status: HttpStatus.OK
     })
 
-    await page.goto('/owner/admins')
+    await page.goto('/admins')
     await apiPromise
 
     // Find the invited admin row and verify status is Active
@@ -329,7 +329,7 @@ test.describe('Owner: Admins Page Error Handling', () => {
       })
     )
 
-    await page.goto('/owner/admins')
+    await page.goto('/admins')
 
     await expect(
       page.getByText(t.backend['system/internal-error'])
@@ -353,7 +353,7 @@ test.describe('Owner: Admins Page Error Handling', () => {
       })
     )
 
-    await page.goto('/owner/admins')
+    await page.goto('/admins')
 
     // Verify table header is visible but no data rows exist
     await expect(

--- a/apps/admin/src/router.jsx
+++ b/apps/admin/src/router.jsx
@@ -94,7 +94,7 @@ export const router = createBrowserRouter([
     ]
   },
   {
-    path: '/owner',
+    path: '/',
     element: (
       <PrivateRoute
         requireStatuses={adminActiveStatuses}
@@ -105,8 +105,17 @@ export const router = createBrowserRouter([
     ),
     errorElement: <ErrorBoundary />,
     children: [
-      { path: 'admins', element: <AdminsPage /> },
-      { path: 'admins/:id', element: <AdminPage /> }
+      {
+        element: (
+          <PrivateRoute requirePermissions={['view:admins']}>
+            <Outlet />
+          </PrivateRoute>
+        ),
+        children: [
+          { path: 'admins', element: <AdminsPage /> },
+          { path: 'admins/:id', element: <AdminPage /> }
+        ]
+      }
     ]
   },
   {

--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -542,7 +542,7 @@ test.describe('Authentication: General', () => {
 
     await page.waitForURL('/home')
 
-    const unauthorizedPaths = ['/unknown', '/owner/admins']
+    const unauthorizedPaths = ['/unknown', '/admins']
 
     for (const path of unauthorizedPaths) {
       await page.goto(path)

--- a/packages/ui/src/components/Sidebar/menu.js
+++ b/packages/ui/src/components/Sidebar/menu.js
@@ -55,7 +55,7 @@ export const getAdminMenuItems = ({
     ? [{ title: 'sidebar.teams', url: '/teams', icon: Users }]
     : []),
   ...(canViewAdmins
-    ? [{ title: 'sidebar.admins', url: '/owner/admins', icon: ShieldCheck }]
+    ? [{ title: 'sidebar.admins', url: '/admins', icon: ShieldCheck }]
     : []),
   {
     title: 'sidebar.settings',

--- a/packages/ui/src/components/profile/PermissionsSection.jsx
+++ b/packages/ui/src/components/profile/PermissionsSection.jsx
@@ -13,7 +13,8 @@ export const PermissionsSection = ({
   isLoading,
   permissions,
   update,
-  isUpdating
+  isUpdating,
+  readOnly = false
 }) => {
   const { t, te } = useLocale()
   const { showSuccessToast, showErrorToast } = useToast()
@@ -49,9 +50,11 @@ export const PermissionsSection = ({
         permissions={permissions}
         isLoading={isLoading}
       />
-      <FormActions isDirty={isDirty}>
-        <SubmitButton isLoading={isUpdating}>{t('save')}</SubmitButton>
-      </FormActions>
+      {!readOnly && (
+        <FormActions isDirty={isDirty}>
+          <SubmitButton isLoading={isUpdating}>{t('save')}</SubmitButton>
+        </FormActions>
+      )}
     </FormRoot>
   )
 }

--- a/packages/ui/src/pages/owner/Admin/AdminPage.jsx
+++ b/packages/ui/src/pages/owner/Admin/AdminPage.jsx
@@ -9,6 +9,7 @@ import {
 import { Spinner } from '@ui/components/Spinner'
 import { ErrorState } from '@ui/components/states'
 import { Tabs, TabsContent, TabsLine } from '@ui/components/ui'
+import { useCurrentUser } from '@ui/hooks/useAuth'
 import { useHashTab } from '@ui/hooks/useHashTab'
 import { useLocale } from '@ui/hooks/useLocale'
 import { useAdmin } from '@ui/hooks/useOwner'
@@ -20,8 +21,11 @@ import { ProfileTab } from './ProfileTab'
 export const AdminPage = () => {
   const { id } = useParams()
   const { t } = useLocale()
+  const { can } = useCurrentUser()
   const [activeTab, setActiveTab] = useHashTab(getAdminTabValues(), Tab.PROFILE)
   const { data: admin, isPending, isError, error, refetch } = useAdmin(id)
+
+  const readOnly = !can('manage:admins')
 
   if (isError) {
     return <ErrorState error={error} onRetry={refetch} />
@@ -40,10 +44,10 @@ export const AdminPage = () => {
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsLine tabs={getAdminTabs(t)} />
         <TabsContent value={Tab.PROFILE}>
-          <ProfileTab admin={admin} />
+          <ProfileTab admin={admin} readOnly={readOnly} />
         </TabsContent>
         <TabsContent value={Tab.PERMISSIONS}>
-          <PermissionsTab adminId={id} />
+          <PermissionsTab adminId={id} readOnly={readOnly} />
         </TabsContent>
       </Tabs>
     </PageContent>

--- a/packages/ui/src/pages/owner/Admin/PermissionsTab.jsx
+++ b/packages/ui/src/pages/owner/Admin/PermissionsTab.jsx
@@ -4,7 +4,7 @@ import {
   useUpdateAdminPermissions
 } from '@ui/hooks/useOwner'
 
-export const PermissionsTab = ({ adminId }) => {
+export const PermissionsTab = ({ adminId, readOnly }) => {
   const { data: permissions, isPending: isLoading } =
     useAdminPermissions(adminId)
   const { mutate: update, isPending: isUpdating } =
@@ -16,6 +16,7 @@ export const PermissionsTab = ({ adminId }) => {
       permissions={permissions}
       update={update}
       isUpdating={isUpdating}
+      readOnly={readOnly}
     />
   )
 }

--- a/packages/ui/src/pages/owner/Admin/ProfileTab.jsx
+++ b/packages/ui/src/pages/owner/Admin/ProfileTab.jsx
@@ -1,8 +1,15 @@
 import { ProfileSection } from '@ui/components/profile'
 import { useUpdateAdmin } from '@ui/hooks/useOwner'
 
-export const ProfileTab = ({ admin }) => {
+export const ProfileTab = ({ admin, readOnly }) => {
   const { mutate, isPending } = useUpdateAdmin(admin.id)
 
-  return <ProfileSection user={admin} update={mutate} isUpdating={isPending} />
+  return (
+    <ProfileSection
+      user={admin}
+      update={mutate}
+      isUpdating={isPending}
+      readOnly={readOnly}
+    />
+  )
 }

--- a/packages/ui/src/pages/owner/Admins/AdminsPage.jsx
+++ b/packages/ui/src/pages/owner/Admins/AdminsPage.jsx
@@ -55,7 +55,7 @@ export const AdminsPage = () => {
   )
   const [sorting, setSorting] = useState([])
 
-  const openAdminProfile = admin => navigate(`/owner/admins/${admin.id}`)
+  const openAdminProfile = admin => navigate(`/admins/${admin.id}`)
 
   const contextMenu = [
     createOpenItem(t, openAdminProfile),

--- a/packages/ui/src/pages/owner/Admins/AdminsPage.jsx
+++ b/packages/ui/src/pages/owner/Admins/AdminsPage.jsx
@@ -34,7 +34,7 @@ const Toolbar = ({ children }) => (
 
 export const AdminsPage = () => {
   const { t, formatDate } = useLocale()
-  const { user: me } = useCurrentUser()
+  const { user: me, can } = useCurrentUser()
   const navigate = useNavigate()
 
   const { apiParams, setParams, searchValue, setSearchValue } = useTableState()
@@ -54,6 +54,8 @@ export const AdminsPage = () => {
     columns
   )
   const [sorting, setSorting] = useState([])
+
+  const readOnly = !can('manage:admins')
 
   const openAdminProfile = admin => navigate(`/admins/${admin.id}`)
 
@@ -111,7 +113,9 @@ export const AdminsPage = () => {
           config={config}
           createLabel={id => t(`table.users.${id}`)}
         />
-        <InviteButton label={t('invite.cta')} onClick={openInviteDialog} />
+        {!readOnly && (
+          <InviteButton label={t('invite.cta')} onClick={openInviteDialog} />
+        )}
       </Toolbar>
 
       <Table


### PR DESCRIPTION
[Feature]: Flatten `/owner/admins` routes to `/admins` — `/owner` prefix added no security value since role guard already enforces access
[Improvement]: Add `view:admins` permission guard to admins route group, consistent with `view:users` and `view:teams` pattern
[Feature]: Gate `InviteButton` on `manage:admins` permission in `AdminsPage`
[Feature]: Propagate `readOnly` flag through `AdminPage` → `ProfileTab` → `ProfileSection` based on `manage:admins` permission
[Feature]: Propagate `readOnly` flag through `AdminPage` → `PermissionsTab` → `PermissionsSection`, hiding save button when read-only
[Fix]: Update all E2E tests and sidebar nav references from `/owner/admins` to `/admins`