### PR TITLE
Replace readOnly props with explicit permission-based can flags

### DIFF
--- a/packages/ui/src/components/form/MembershipForm/MembershipForm.jsx
+++ b/packages/ui/src/components/form/MembershipForm/MembershipForm.jsx
@@ -25,7 +25,7 @@ export const MembershipForm = ({
   teamLink,
   isSubmitting,
   onSubmit,
-  readOnly = false
+  canManageTeams = true
 }) => {
   const { t, formatDate } = useLocale()
 
@@ -61,7 +61,10 @@ export const MembershipForm = ({
             error={errors[FieldName.POSITION]}
             optional
           >
-            <Input {...register(FieldName.POSITION)} readOnly={readOnly} />
+            <Input
+              {...register(FieldName.POSITION)}
+              readOnly={!canManageTeams}
+            />
           </FormField>
         </FormRow>
 
@@ -77,7 +80,7 @@ export const MembershipForm = ({
           )}
         </FormRow>
 
-        {!readOnly && (
+        {canManageTeams && (
           <FormActions isDirty={isDirty}>
             <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
           </FormActions>

--- a/packages/ui/src/components/form/TeamGeneralForm/TeamGeneralForm.jsx
+++ b/packages/ui/src/components/form/TeamGeneralForm/TeamGeneralForm.jsx
@@ -21,7 +21,7 @@ export const TeamGeneralForm = ({
   team,
   isSubmitting,
   onSubmit,
-  readOnly = false
+  canManageTeams = true
 }) => {
   const { t, formatDate } = useLocale()
 
@@ -50,7 +50,7 @@ export const TeamGeneralForm = ({
             name={FieldName.NAME}
             error={errors[FieldName.NAME]}
           >
-            <Input {...register(FieldName.NAME)} readOnly={readOnly} />
+            <Input {...register(FieldName.NAME)} readOnly={!canManageTeams} />
           </FormField>
 
           <FormField
@@ -62,7 +62,7 @@ export const TeamGeneralForm = ({
             <Input
               {...register(FieldName.WEBSITE)}
               placeholder='https://'
-              readOnly={readOnly}
+              readOnly={!canManageTeams}
             />
           </FormField>
         </FormRow>
@@ -73,7 +73,10 @@ export const TeamGeneralForm = ({
           error={errors[FieldName.DESCRIPTION]}
           optional
         >
-          <Textarea {...register(FieldName.DESCRIPTION)} readOnly={readOnly} />
+          <Textarea
+            {...register(FieldName.DESCRIPTION)}
+            readOnly={!canManageTeams}
+          />
         </FormField>
 
         <FormRow forceColumns>
@@ -85,7 +88,7 @@ export const TeamGeneralForm = ({
           </FormField>
         </FormRow>
 
-        {!readOnly && (
+        {canManageTeams && (
           <FormActions isDirty={isDirty}>
             <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
           </FormActions>

--- a/packages/ui/src/components/form/UserInfoForm/UserInfoForm.jsx
+++ b/packages/ui/src/components/form/UserInfoForm/UserInfoForm.jsx
@@ -31,7 +31,7 @@ export const UserInfoForm = ({
   isSubmitting,
   onSubmit,
   formFields = {},
-  readOnly = false
+  canManageUsers = true
 }) => {
   const fields = { ...defaultFields, ...formFields }
   const { t, formatDate } = useLocale()
@@ -65,7 +65,10 @@ export const UserInfoForm = ({
             name={FieldName.FIRST_NAME}
             error={errors[FieldName.FIRST_NAME]}
           >
-            <Input {...register(FieldName.FIRST_NAME)} readOnly={readOnly} />
+            <Input
+              {...register(FieldName.FIRST_NAME)}
+              readOnly={!canManageUsers}
+            />
           </FormField>
 
           <FormField
@@ -74,7 +77,10 @@ export const UserInfoForm = ({
             error={errors[FieldName.LAST_NAME]}
             optional
           >
-            <Input {...register(FieldName.LAST_NAME)} readOnly={readOnly} />
+            <Input
+              {...register(FieldName.LAST_NAME)}
+              readOnly={!canManageUsers}
+            />
           </FormField>
         </FormRow>
 
@@ -89,7 +95,7 @@ export const UserInfoForm = ({
                   id={id}
                   value={field.value}
                   onChange={field.onChange}
-                  readOnly={readOnly}
+                  readOnly={!canManageUsers}
                 />
               )}
             />
@@ -105,7 +111,7 @@ export const UserInfoForm = ({
           </FormField>
         </FormRow>
 
-        {!readOnly && (
+        {canManageUsers && (
           <FormActions isDirty={isDirty}>
             <SubmitButton isLoading={isSubmitting}>{t('save')}</SubmitButton>
           </FormActions>

--- a/packages/ui/src/components/profile/MembershipSection.jsx
+++ b/packages/ui/src/components/profile/MembershipSection.jsx
@@ -13,7 +13,7 @@ export const MembershipSection = ({
   teamLink,
   update,
   isUpdating,
-  readOnly = false
+  canManageTeams = true
 }) => {
   const { t, te } = useLocale()
   const { user: me } = useCurrentUser()
@@ -38,9 +38,9 @@ export const MembershipSection = ({
         teamLink={teamLink}
         isSubmitting={isUpdating}
         onSubmit={handleUpdate}
-        readOnly={readOnly}
+        canManageTeams={canManageTeams}
       />
-      {!readOnly && me?.id !== member?.id && (
+      {canManageTeams && me?.id !== member?.id && (
         <>
           <TextSeparator />
           <RemoveMemberItem member={member} teamId={team?.id} />

--- a/packages/ui/src/components/profile/PermissionsSection.jsx
+++ b/packages/ui/src/components/profile/PermissionsSection.jsx
@@ -14,7 +14,7 @@ export const PermissionsSection = ({
   permissions,
   update,
   isUpdating,
-  readOnly = false
+  canManageAdmins = true
 }) => {
   const { t, te } = useLocale()
   const { showSuccessToast, showErrorToast } = useToast()
@@ -50,7 +50,7 @@ export const PermissionsSection = ({
         permissions={permissions}
         isLoading={isLoading}
       />
-      {!readOnly && (
+      {canManageAdmins && (
         <FormActions isDirty={isDirty}>
           <SubmitButton isLoading={isUpdating}>{t('save')}</SubmitButton>
         </FormActions>

--- a/packages/ui/src/components/profile/ProfileSection.jsx
+++ b/packages/ui/src/components/profile/ProfileSection.jsx
@@ -7,7 +7,7 @@ export const ProfileSection = ({
   update,
   isUpdating,
   formFields,
-  readOnly = false
+  canManageUsers = true
 }) => {
   const { t, te } = useLocale()
   const { showSuccessToast, showErrorToast } = useToast()
@@ -29,7 +29,7 @@ export const ProfileSection = ({
       isSubmitting={isUpdating}
       onSubmit={handleUpdate}
       formFields={formFields}
-      readOnly={readOnly}
+      canManageUsers={canManageUsers}
     />
   )
 }

--- a/packages/ui/src/components/team/TeamGeneralSection.jsx
+++ b/packages/ui/src/components/team/TeamGeneralSection.jsx
@@ -3,7 +3,7 @@ import { useLocale } from '@ui/hooks/useLocale'
 import { useUpdateTeam } from '@ui/hooks/useTeam'
 import { useToast } from '@ui/hooks/useToast'
 
-export const TeamGeneralSection = ({ team, readOnly = false }) => {
+export const TeamGeneralSection = ({ team, canManageTeams = true }) => {
   const { t, te } = useLocale()
   const { showSuccessToast, showErrorToast } = useToast()
   const { mutate: updateTeam, isPending: isUpdating } = useUpdateTeam(team.id)
@@ -24,7 +24,7 @@ export const TeamGeneralSection = ({ team, readOnly = false }) => {
       team={team}
       isSubmitting={isUpdating}
       onSubmit={handleUpdateTeam}
-      readOnly={readOnly}
+      canManageTeams={canManageTeams}
     />
   )
 }

--- a/packages/ui/src/components/team/TeamMembersSection/TeamMembersSection.jsx
+++ b/packages/ui/src/components/team/TeamMembersSection/TeamMembersSection.jsx
@@ -56,8 +56,7 @@ export const TeamMembersSection = ({
   const contextMenu = [
     createOpenItem(t, openMemberProfile),
     ...(canManageTeams
-      ? [] // don't show invite and remove options in context menu
-      : [
+      ? [
           createInviteItem(t, {
             handleResendInvite,
             isResending,
@@ -69,7 +68,8 @@ export const TeamMembersSection = ({
             isDeleting,
             meId: me?.id
           })
-        ])
+        ]
+      : [])
   ]
 
   const columns = getColumns(t, formatDate, me?.id)

--- a/packages/ui/src/components/team/TeamMembersSection/TeamMembersSection.jsx
+++ b/packages/ui/src/components/team/TeamMembersSection/TeamMembersSection.jsx
@@ -31,7 +31,7 @@ export const TeamMembersSection = ({
   teamId,
   onRowClick,
   queryOptions = {},
-  readOnly = false
+  canManageTeams = true
 }) => {
   const { t, formatDate } = useLocale()
   const { user: me } = useCurrentUser()
@@ -55,7 +55,7 @@ export const TeamMembersSection = ({
 
   const contextMenu = [
     createOpenItem(t, openMemberProfile),
-    ...(readOnly
+    ...(canManageTeams
       ? [] // don't show invite and remove options in context menu
       : [
           createInviteItem(t, {
@@ -98,7 +98,7 @@ export const TeamMembersSection = ({
   if (!members.length) {
     return (
       <EmptyState text={t('team.members.empty')}>
-        {!readOnly && (
+        {canManageTeams && (
           <InviteButton
             label={t('invite.cta')}
             onClick={openInviteDialog}
@@ -116,7 +116,7 @@ export const TeamMembersSection = ({
           config={config}
           createLabel={id => t(`table.members.${id}`)}
         />
-        {!readOnly && (
+        {canManageTeams && (
           <InviteButton label={t('invite.cta')} onClick={openInviteDialog} />
         )}
       </TeamMembersToolbar>

--- a/packages/ui/src/pages/admin/Team/TeamPage.jsx
+++ b/packages/ui/src/pages/admin/Team/TeamPage.jsx
@@ -27,7 +27,7 @@ export const TeamPage = () => {
     TeamTab.GENERAL
   )
 
-  const readOnly = !can('manage:teams')
+  const canManageTeams = can('manage:teams')
 
   const {
     data: team,
@@ -56,12 +56,12 @@ export const TeamPage = () => {
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsLine tabs={getTeamTabs(team, t)} />
         <TabsContent value={TeamTab.GENERAL}>
-          <TeamGeneralSection team={team} readOnly={readOnly} />
+          <TeamGeneralSection team={team} canManageTeams={canManageTeams} />
         </TabsContent>
         <TabsContent value={TeamTab.MEMBERS}>
           <TeamMembersSection
             teamId={teamId}
-            readOnly={readOnly}
+            canManageTeams={canManageTeams}
             onRowClick={member =>
               navigate(`/users/${member.id}`, { state: { user: member } })
             }

--- a/packages/ui/src/pages/admin/Teams/TeamsPage.jsx
+++ b/packages/ui/src/pages/admin/Teams/TeamsPage.jsx
@@ -40,7 +40,7 @@ export const TeamsPage = () => {
     useTeams(apiParams)
   const { openCreateTeamDialog } = useManageTeams()
 
-  const readOnly = !can('manage:teams')
+  const canManageTeams = can('manage:teams')
 
   const columns = getColumns(t, formatDate)
   const [columnVisibility, setColumnVisibility] = useColumnVisibility(
@@ -97,7 +97,7 @@ export const TeamsPage = () => {
           config={config}
           createLabel={id => t(`table.teams.${id}`)}
         />
-        {!readOnly && (
+        {canManageTeams && (
           <AddButton label={t('add')} onClick={openCreateTeamDialog} />
         )}
       </Toolbar>

--- a/packages/ui/src/pages/admin/User/MembershipTab.jsx
+++ b/packages/ui/src/pages/admin/User/MembershipTab.jsx
@@ -1,7 +1,7 @@
 import { MembershipSection } from '@ui/components/profile'
 import { useTeamMember, useUpdateTeamMember } from '@ui/hooks/useTeam'
 
-export const MembershipTab = ({ user, team, readOnly = false }) => {
+export const MembershipTab = ({ user, team, canManageTeams = true }) => {
   const { data: member } = useTeamMember(team.id, user.id)
   const { mutate, isPending: isUpdating } = useUpdateTeamMember(
     team.id,
@@ -16,7 +16,7 @@ export const MembershipTab = ({ user, team, readOnly = false }) => {
       teamLink={`/teams/${team.id}`}
       update={update}
       isUpdating={isUpdating}
-      readOnly={readOnly}
+      canManageTeams={canManageTeams}
     />
   )
 }

--- a/packages/ui/src/pages/admin/User/ProfileTab.jsx
+++ b/packages/ui/src/pages/admin/User/ProfileTab.jsx
@@ -1,7 +1,7 @@
 import { ProfileSection } from '@ui/components/profile'
 import { useUpdateUser } from '@ui/hooks/useAdmin'
 
-export const ProfileTab = ({ user, readOnly = false }) => {
+export const ProfileTab = ({ user, canManageUsers = true }) => {
   const { mutate, isPending } = useUpdateUser(user.id)
 
   return (
@@ -9,7 +9,7 @@ export const ProfileTab = ({ user, readOnly = false }) => {
       user={user}
       update={mutate}
       isUpdating={isPending}
-      readOnly={readOnly}
+      canManageUsers={canManageUsers}
     />
   )
 }

--- a/packages/ui/src/pages/admin/User/UserPage.jsx
+++ b/packages/ui/src/pages/admin/User/UserPage.jsx
@@ -34,13 +34,15 @@ export const UserPage = () => {
     initialData: state?.user ? { user: state.user } : undefined
   })
 
-  const hasMembership = !isPending && !!user?.team
+  const canViewTeams = can('view:teams')
+  const canManageTeams = can('manage:teams')
+  const hasMembership = !isPending && !!user?.team && canViewTeams
   const [activeTab, setActiveTab] = useHashTab(
     getUserTabValues(hasMembership),
     Tab.PROFILE
   )
 
-  const readOnly = !can('manage:users')
+  const canManageUsers = can('manage:users')
 
   if (isError) {
     return <ErrorState error={error} onRetry={refetch} />
@@ -59,11 +61,15 @@ export const UserPage = () => {
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsLine tabs={getUserTabs(hasMembership, t)} />
         <TabsContent value={Tab.PROFILE}>
-          <ProfileTab user={user} readOnly={readOnly} />
+          <ProfileTab user={user} canManageUsers={canManageUsers} />
         </TabsContent>
         {hasMembership && (
           <TabsContent value={Tab.MEMBERSHIP}>
-            <MembershipTab user={user} team={user?.team} readOnly={readOnly} />
+            <MembershipTab
+              user={user}
+              team={user?.team}
+              canManageTeams={canManageTeams}
+            />
           </TabsContent>
         )}
       </Tabs>

--- a/packages/ui/src/pages/owner/Admin/AdminPage.jsx
+++ b/packages/ui/src/pages/owner/Admin/AdminPage.jsx
@@ -25,7 +25,7 @@ export const AdminPage = () => {
   const [activeTab, setActiveTab] = useHashTab(getAdminTabValues(), Tab.PROFILE)
   const { data: admin, isPending, isError, error, refetch } = useAdmin(id)
 
-  const readOnly = !can('manage:admins')
+  const canManageAdmins = can('manage:admins')
 
   if (isError) {
     return <ErrorState error={error} onRetry={refetch} />
@@ -44,10 +44,10 @@ export const AdminPage = () => {
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsLine tabs={getAdminTabs(t)} />
         <TabsContent value={Tab.PROFILE}>
-          <ProfileTab admin={admin} readOnly={readOnly} />
+          <ProfileTab admin={admin} canManageAdmins={canManageAdmins} />
         </TabsContent>
         <TabsContent value={Tab.PERMISSIONS}>
-          <PermissionsTab adminId={id} readOnly={readOnly} />
+          <PermissionsTab adminId={id} canManageAdmins={canManageAdmins} />
         </TabsContent>
       </Tabs>
     </PageContent>

--- a/packages/ui/src/pages/owner/Admin/PermissionsTab.jsx
+++ b/packages/ui/src/pages/owner/Admin/PermissionsTab.jsx
@@ -4,7 +4,7 @@ import {
   useUpdateAdminPermissions
 } from '@ui/hooks/useOwner'
 
-export const PermissionsTab = ({ adminId, readOnly }) => {
+export const PermissionsTab = ({ adminId, canManageAdmins = true }) => {
   const { data: permissions, isPending: isLoading } =
     useAdminPermissions(adminId)
   const { mutate: update, isPending: isUpdating } =
@@ -16,7 +16,7 @@ export const PermissionsTab = ({ adminId, readOnly }) => {
       permissions={permissions}
       update={update}
       isUpdating={isUpdating}
-      readOnly={readOnly}
+      canManageAdmins={canManageAdmins}
     />
   )
 }

--- a/packages/ui/src/pages/owner/Admin/ProfileTab.jsx
+++ b/packages/ui/src/pages/owner/Admin/ProfileTab.jsx
@@ -1,7 +1,7 @@
 import { ProfileSection } from '@ui/components/profile'
 import { useUpdateAdmin } from '@ui/hooks/useOwner'
 
-export const ProfileTab = ({ admin, readOnly }) => {
+export const ProfileTab = ({ admin, canManageAdmins = true }) => {
   const { mutate, isPending } = useUpdateAdmin(admin.id)
 
   return (
@@ -9,7 +9,7 @@ export const ProfileTab = ({ admin, readOnly }) => {
       user={admin}
       update={mutate}
       isUpdating={isPending}
-      readOnly={readOnly}
+      canManageUsers={canManageAdmins}
     />
   )
 }

--- a/packages/ui/src/pages/owner/Admins/AdminsPage.jsx
+++ b/packages/ui/src/pages/owner/Admins/AdminsPage.jsx
@@ -55,7 +55,7 @@ export const AdminsPage = () => {
   )
   const [sorting, setSorting] = useState([])
 
-  const readOnly = !can('manage:admins')
+  const canManageAdmins = can('manage:admins')
 
   const openAdminProfile = admin => navigate(`/admins/${admin.id}`)
 
@@ -113,7 +113,7 @@ export const AdminsPage = () => {
           config={config}
           createLabel={id => t(`table.users.${id}`)}
         />
-        {!readOnly && (
+        {canManageAdmins && (
           <InviteButton label={t('invite.cta')} onClick={openInviteDialog} />
         )}
       </Toolbar>


### PR DESCRIPTION
[Improvement]: Replace boolean `readOnly` props with explicit `canManageUsers`, `canManageTeams`, and `canManageAdmins` flags across all admin/owner pages and shared components — makes permission intent clear at the call site
[Fix]: Membership tab on `/users/:id` now hidden when admin lacks `view:teams` permission, not just when user has no team
[Fix]: Remove team member action now gated on `manage:teams` instead of `manage:users`
[Fix]: Team members context menu invite/remove items were inverted — shown when `canManageTeams` was false, hidden when true
[Fix]: `ProfileTab` in owner admin pages was silently passing `readOnly` to `ProfileSection` which expected `canManageUsers` — prop was dropped