### PR TITLE
Fix form submit blocked when API returns partial permissions

### DIFF
--- a/packages/ui/src/components/form/PermissionsMatrix.jsx
+++ b/packages/ui/src/components/form/PermissionsMatrix.jsx
@@ -53,13 +53,13 @@ const PermissionRow = ({ resourceName, resourceData, control }) => {
   const { field: viewField } = useController({
     name: `permissions.${resourceName}.view`,
     control,
-    defaultValue: resourceData.view
+    defaultValue: resourceData.view ?? false
   })
 
   const { field: manageField } = useController({
     name: `permissions.${resourceName}.manage`,
     control,
-    defaultValue: resourceData.manage
+    defaultValue: resourceData.manage ?? false
   })
 
   const handleViewChange = checked => {


### PR DESCRIPTION
## Summary

- `PermissionsMatrix` registered `permissions.{resource}.manage` via `useController` with `defaultValue: resourceData.manage`, which was `undefined` when the API omits the key (intentional — only `view` is returned when `manage` is not granted)
- Zod schema (`z.boolean()`) rejected `undefined`, causing silent form validation failure on submit
- Fixed by defaulting missing action values to `false` with `?? false`

## Test plan

- [ ] Open invite member dialog — submit should work with partial permissions from API
- [ ] Verify unset permissions default to `false` (toggles off) in the matrix
- [ ] Admin invite dialog (full permissions) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)