### PR TITLE
Remove manual chunks and add route-based lazy loading

### DIFF
--- a/apps/admin/src/router.jsx
+++ b/apps/admin/src/router.jsx
@@ -8,11 +8,7 @@ import {
   UserPage,
   UsersPage
 } from '@smela/ui/pages/admin'
-import {
-  AcceptInvitePage,
-  LoginPage,
-  ResetPasswordPage
-} from '@smela/ui/pages/auth'
+import { LoginPage } from '@smela/ui/pages/auth'
 import {
   ForbiddenErrorPage,
   GeneralErrorPage,
@@ -50,8 +46,20 @@ export const router = createBrowserRouter([
           />
         )
       },
-      { path: 'reset-password', element: <ResetPasswordPage /> },
-      { path: 'accept-invite', element: <AcceptInvitePage /> }
+      {
+        path: 'reset-password',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.ResetPasswordPage
+          }))
+      },
+      {
+        path: 'accept-invite',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.AcceptInvitePage
+          }))
+      }
     ]
   },
   {

--- a/apps/admin/vite.config.js
+++ b/apps/admin/vite.config.js
@@ -27,11 +27,7 @@ export default defineConfig({
       output: {
         assetFileNames: 'assets/[name].[hash][extname]',
         chunkFileNames: 'assets/[name].[hash].js',
-        entryFileNames: 'assets/[name].[hash].js',
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          router: ['react-router-dom']
-        }
+        entryFileNames: 'assets/[name].[hash].js'
       }
     }
   },

--- a/apps/web/src/router.jsx
+++ b/apps/web/src/router.jsx
@@ -21,7 +21,6 @@ import {
   NetworkErrorPage,
   NotFoundErrorPage
 } from '@smela/ui/pages/errors'
-import { PrivacyPage, TermsPage } from '@smela/ui/pages/legal'
 import { PricingPage } from '@smela/ui/pages/public'
 import {
   HomePage,
@@ -68,8 +67,20 @@ export const router = createBrowserRouter([
     element: <LegalLayout />,
     errorElement: <ErrorBoundary />,
     children: [
-      { path: 'terms', element: <TermsPage /> },
-      { path: 'privacy', element: <PrivacyPage /> }
+      {
+        path: 'terms',
+        lazy: () =>
+          import('@smela/ui/pages/legal').then(m => ({
+            Component: m.TermsPage
+          }))
+      },
+      {
+        path: 'privacy',
+        lazy: () =>
+          import('@smela/ui/pages/legal').then(m => ({
+            Component: m.PrivacyPage
+          }))
+      }
     ]
   },
   {

--- a/apps/web/src/router.jsx
+++ b/apps/web/src/router.jsx
@@ -7,14 +7,7 @@ import {
   UserLayout
 } from '@smela/ui/layouts'
 import { Role, userActiveStatuses } from '@smela/ui/lib/types'
-import {
-  AcceptInvitePage,
-  EmailConfirmationPage,
-  LoginPage,
-  ResetPasswordPage,
-  SignupPage,
-  VerifyEmailPage
-} from '@smela/ui/pages/auth'
+import { LoginPage } from '@smela/ui/pages/auth'
 import {
   ForbiddenErrorPage,
   GeneralErrorPage,
@@ -56,11 +49,41 @@ export const router = createBrowserRouter([
     errorElement: <ErrorBoundary />,
     children: [
       { path: 'login', element: <LoginPage /> },
-      { path: 'signup', element: <SignupPage /> },
-      { path: 'reset-password', element: <ResetPasswordPage /> },
-      { path: 'accept-invite', element: <AcceptInvitePage /> },
-      { path: 'email-confirmation', element: <EmailConfirmationPage /> },
-      { path: 'verify-email', element: <VerifyEmailPage /> }
+      {
+        path: 'signup',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.SignupPage
+          }))
+      },
+      {
+        path: 'reset-password',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.ResetPasswordPage
+          }))
+      },
+      {
+        path: 'accept-invite',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.AcceptInvitePage
+          }))
+      },
+      {
+        path: 'email-confirmation',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.EmailConfirmationPage
+          }))
+      },
+      {
+        path: 'verify-email',
+        lazy: () =>
+          import('@smela/ui/pages/auth').then(m => ({
+            Component: m.VerifyEmailPage
+          }))
+      }
     ]
   },
   {

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -21,11 +21,7 @@ export default defineConfig({
       output: {
         assetFileNames: 'assets/[name].[hash][extname]',
         chunkFileNames: 'assets/[name].[hash].js',
-        entryFileNames: 'assets/[name].[hash].js',
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          router: ['react-router-dom']
-        }
+        entryFileNames: 'assets/[name].[hash].js'
       }
     }
   },


### PR DESCRIPTION
- Remove `manualChunks` from `apps/web` and `apps/admin` Vite configs — React 19 ships ESM so Rollup cannot split it into manual chunks, causing empty chunk warnings
- Lazy load `TermsPage` and `PrivacyPage` in `apps/web` router — legal pages are rarely visited and don't need to be in the initial bundle
- Lazy load all non-login auth pages (`SignupPage`, `ResetPasswordPage`, `AcceptInvitePage`, `EmailConfirmationPage`, `VerifyEmailPage`) in `apps/web` router — users land on login; other auth routes load on demand
- Lazy load `ResetPasswordPage` and `AcceptInvitePage` in `apps/admin` router — same rationale; login stays static
- All lazy auth routes share one `import('@smela/ui/pages/auth')` call so Rollup emits a single chunk, cached after first fetch