### PR TITLE
Apply RBAC to team routes in web app

### DIFF
--- a/apps/web/src/router.jsx
+++ b/apps/web/src/router.jsx
@@ -120,7 +120,11 @@ export const router = createBrowserRouter([
       { path: 'home', element: <HomePage /> },
       {
         path: 'team',
-        element: <TeamLayout />,
+        element: (
+          <PrivateRoute requirePermissions={['view:teams']}>
+            <TeamLayout />
+          </PrivateRoute>
+        ),
         children: [
           { index: true, element: <Navigate to='general' replace /> },
           { path: 'general', element: <TeamGeneralPage /> },

--- a/apps/web/src/router.jsx
+++ b/apps/web/src/router.jsx
@@ -131,7 +131,14 @@ export const router = createBrowserRouter([
           { path: 'members', element: <TeamMembersPage /> }
         ]
       },
-      { path: 'team/members/:id', element: <TeamMemberPage /> },
+      {
+        path: 'team/members/:id',
+        element: (
+          <PrivateRoute requirePermissions={['view:teams']}>
+            <TeamMemberPage />
+          </PrivateRoute>
+        )
+      },
       { path: 'profile', element: <ProfilePage /> },
       { path: 'settings', element: <UserSettingsPage /> }
     ]

--- a/packages/ui/src/pages/user/Team/TeamGeneralPage.jsx
+++ b/packages/ui/src/pages/user/Team/TeamGeneralPage.jsx
@@ -1,8 +1,12 @@
 import { TeamGeneralSection } from '@ui/components/team'
+import { useCurrentUser } from '@ui/hooks/useAuth'
 import { useOutletContext } from '@ui/hooks/useRouter'
 
 export const TeamGeneralPage = () => {
   const { team } = useOutletContext()
+  const { can } = useCurrentUser()
 
-  return <TeamGeneralSection team={team} />
+  const canManageTeams = can('manage:teams')
+
+  return <TeamGeneralSection team={team} canManageTeams={canManageTeams} />
 }

--- a/packages/ui/src/pages/user/Team/TeamMembersPage.jsx
+++ b/packages/ui/src/pages/user/Team/TeamMembersPage.jsx
@@ -1,14 +1,19 @@
 import { TeamMembersSection } from '@ui/components/team'
+import { useCurrentUser } from '@ui/hooks/useAuth'
 import { useNavigate, useOutletContext } from '@ui/hooks/useRouter'
 import { userTeamQueryOptions } from '@ui/hooks/useTeam'
 
 export const TeamMembersPage = () => {
   const { team } = useOutletContext()
   const navigate = useNavigate()
+  const { can } = useCurrentUser()
+
+  const canManageTeams = can('manage:teams')
 
   return (
     <TeamMembersSection
       teamId={team.id}
+      canManageTeams={canManageTeams}
       onRowClick={member =>
         navigate(`/team/members/${member.id}`, { state: { member } })
       }


### PR DESCRIPTION
## Changes

- Gate `/team` and all sub-routes (`/team/general`, `/team/members`, `/team/members/:id`) with `requirePermissions={['view:teams']}` via nested `PrivateRoute`
- Derive `canManageTeams` from `can('manage:teams')` in `TeamGeneralPage` and pass to `TeamGeneralSection` — stops hardcoded `true` default
- Same for `TeamMembersPage` → `TeamMembersSection` (controls invite/remove actions and form editability)
- Follows the same pattern already established in the admin app (`packages/ui/src/pages/admin/Team/TeamPage.jsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)