### PR TITLE
Add requirePermission middleware for owner routes

### DIFF
--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -19,6 +19,8 @@ export {
 
 export { requestValidator } from './request-validator'
 
+export { requirePermission } from './require-permission'
+
 export { secureHeadersMiddleware } from './secure-headers'
 
 export {

--- a/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
+++ b/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+
+import type { AppContext } from '@/context'
+
+import { testUuids } from '@/__tests__'
+import { ErrorCode } from '@/errors'
+import { onError } from '@/handlers'
+import HttpStatus from '@/net/http/status'
+import { Role, UserStatus } from '@/types'
+import Permission from '@/types/permission'
+
+import { requirePermission } from '../require-permission'
+
+describe('requirePermission Middleware', () => {
+  let app: Hono<AppContext>
+
+  beforeEach(() => {
+    app = new Hono<AppContext>()
+    app.onError(onError)
+  })
+
+  const setUser =
+    (permissions?: string[]) => async (c: any, next: () => Promise<void>) => {
+      c.set('user', {
+        id: testUuids.USER_1,
+        email: 'user@example.com',
+        role: Role.User,
+        status: UserStatus.Active,
+        permissions
+      })
+      await next()
+    }
+
+  describe('Permission granted', () => {
+    it('should allow request when permission is in claims', async () => {
+      app.use('/', setUser([Permission.ViewAdmins]))
+      app.use('/', requirePermission(Permission.ViewAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.OK)
+      const json = await res.json()
+      expect(json.message).toBe('success')
+    })
+
+    it('should allow request when multiple permissions include required one', async () => {
+      app.use(
+        '/',
+        setUser([
+          Permission.ViewDashboard,
+          Permission.ViewAdmins,
+          Permission.ManageUsers
+        ])
+      )
+      app.use('/', requirePermission(Permission.ViewAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.OK)
+    })
+
+    it('should allow Owner with required permission', async () => {
+      app.use('/', async (c, next) => {
+        c.set('user', {
+          id: testUuids.OWNER_1,
+          email: 'owner@example.com',
+          role: Role.Owner,
+          status: UserStatus.Active,
+          permissions: [Permission.ViewAdmins, Permission.ManageAdmins]
+        })
+        await next()
+      })
+      app.use('/', requirePermission(Permission.ManageAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.OK)
+    })
+  })
+
+  describe('Permission denied', () => {
+    it('should throw Forbidden when permission is missing from claims', async () => {
+      app.use('/', setUser([Permission.ViewDashboard]))
+      app.use('/', requirePermission(Permission.ViewAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      const json = await res.json()
+      expect(json.code).toBe(ErrorCode.Forbidden)
+    })
+
+    it('should throw Forbidden when permissions is undefined', async () => {
+      app.use('/', setUser(undefined))
+      app.use('/', requirePermission(Permission.ViewAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      const json = await res.json()
+      expect(json.code).toBe(ErrorCode.Forbidden)
+    })
+
+    it('should throw Forbidden when permissions is empty', async () => {
+      app.use('/', setUser([]))
+      app.use('/', requirePermission(Permission.ViewAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      const json = await res.json()
+      expect(json.code).toBe(ErrorCode.Forbidden)
+    })
+
+    it('should throw Forbidden when Owner lacks required permission', async () => {
+      app.use('/', async (c, next) => {
+        c.set('user', {
+          id: testUuids.OWNER_1,
+          email: 'owner@example.com',
+          role: Role.Owner,
+          status: UserStatus.Active,
+          permissions: [Permission.ViewDashboard]
+        })
+        await next()
+      })
+      app.use('/', requirePermission(Permission.ManageAdmins))
+      app.get('/', c => c.json({ message: 'success' }))
+
+      const res = await app.request('/')
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      const json = await res.json()
+      expect(json.code).toBe(ErrorCode.Forbidden)
+    })
+  })
+})

--- a/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
+++ b/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
@@ -96,7 +96,7 @@ describe('requirePermission Middleware', () => {
     })
 
     it('should throw Forbidden when permissions is undefined', async () => {
-      app.use('/', setUser(undefined))
+      app.use('/', setUser())
       app.use('/', requirePermission(Permission.ViewAdmins))
       app.get('/', c => c.json({ message: 'success' }))
 

--- a/apps/api/src/middleware/require-permission/index.ts
+++ b/apps/api/src/middleware/require-permission/index.ts
@@ -1,0 +1,1 @@
+export { requirePermission } from './require-permission'

--- a/apps/api/src/middleware/require-permission/require-permission.ts
+++ b/apps/api/src/middleware/require-permission/require-permission.ts
@@ -1,0 +1,17 @@
+import { createMiddleware } from 'hono/factory'
+
+import type { AppContext } from '@/context'
+import type { Permission } from '@/types'
+
+import { AppError, ErrorCode } from '@/errors'
+
+export const requirePermission = (permission: Permission) =>
+  createMiddleware<AppContext>(async (c, next) => {
+    const { permissions } = c.get('user')
+
+    if (!permissions?.includes(permission)) {
+      throw new AppError(ErrorCode.Forbidden)
+    }
+
+    return next()
+  })

--- a/apps/api/src/routes/owner/admins/$id/index.ts
+++ b/apps/api/src/routes/owner/admins/$id/index.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { requestValidator, requirePermission } from '@/middleware'
+import Permission from '@/types/permission'
 
 import {
   cancelAdminInviteHandler,
@@ -18,6 +19,7 @@ export const ownerAdminByIdRoute = new Hono<AppContext>()
 ownerAdminByIdRoute.get(
   '/',
   requestValidator('param', adminIdParamsSchema),
+  requirePermission(Permission.ViewAdmins),
   getAdminHandler
 )
 
@@ -25,18 +27,21 @@ ownerAdminByIdRoute.patch(
   '/',
   requestValidator('param', adminIdParamsSchema),
   requestValidator('json', updateAdminBodySchema),
+  requirePermission(Permission.ManageAdmins),
   updateAdminHandler
 )
 
 ownerAdminByIdRoute.post(
   '/resend-invite',
   requestValidator('param', adminIdParamsSchema),
+  requirePermission(Permission.ManageAdmins),
   resendAdminInviteHandler
 )
 
 ownerAdminByIdRoute.post(
   '/cancel-invite',
   requestValidator('param', adminIdParamsSchema),
+  requirePermission(Permission.ManageAdmins),
   cancelAdminInviteHandler
 )
 

--- a/apps/api/src/routes/owner/admins/$id/permissions/index.ts
+++ b/apps/api/src/routes/owner/admins/$id/permissions/index.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { requestValidator, requirePermission } from '@/middleware'
+import Permission from '@/types/permission'
 
 import {
   getAdminPermissionsHandler,
@@ -15,6 +16,7 @@ export const ownerAdminPermissionsRoute = new Hono<AppContext>()
 ownerAdminPermissionsRoute.get(
   '/',
   requestValidator('param', adminIdParamsSchema),
+  requirePermission(Permission.ViewAdmins),
   getAdminPermissionsHandler
 )
 
@@ -22,5 +24,6 @@ ownerAdminPermissionsRoute.patch(
   '/',
   requestValidator('param', adminIdParamsSchema),
   requestValidator('json', updateAdminPermissionsBodySchema),
+  requirePermission(Permission.ManageAdmins),
   updateAdminPermissionsHandler
 )

--- a/apps/api/src/routes/owner/admins/index.ts
+++ b/apps/api/src/routes/owner/admins/index.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { requestValidator, requirePermission } from '@/middleware'
+import Permission from '@/types/permission'
 
 import { ownerAdminByIdRoute } from './$id'
 import {
@@ -17,17 +18,20 @@ export const ownerAdminsRoute = new Hono<AppContext>()
 ownerAdminsRoute.get(
   '/admins',
   requestValidator('query', getAdminsQuerySchema),
+  requirePermission(Permission.ViewAdmins),
   getAdminsHandler
 )
 
 ownerAdminsRoute.post(
   '/admins',
   requestValidator('json', createAdminBodySchema),
+  requirePermission(Permission.ManageAdmins),
   createAdminHandler
 )
 
 ownerAdminsRoute.get(
   '/admins/default-permissions',
+  requirePermission(Permission.ViewAdmins),
   getAdminDefaultPermissionsHandler
 )
 


### PR DESCRIPTION
## Summary

- Add `requirePermission(permission)` middleware that checks JWT claims for a required permission string and throws `403 Forbidden` if absent
- No role bypass — owners and admins alike must have the permission in their JWT claims
- Wire all 9 owner/admins routes with `view:admins` (GET) or `manage:admins` (POST/PATCH) checks, placed after `requestValidator` and before the handler
- Export `requirePermission` from `src/middleware/index.ts`
- Add 7 unit tests covering granted/denied cases including `undefined`, empty, and partial permission arrays
- Add 2 route-level integration tests for `GET /admins` verifying permission allowed and denied end-to-end
- Fix redundant `undefined` argument in `requirePermission` unit test (SonarCloud warning)

## Test plan

- [ ] `bun test src/middleware/require-permission` — all 7 pass
- [ ] `bun test src/routes/owner/admins/__tests__/index.test.ts` — both pass
- [ ] `bun run check` — lint, tsc, full test suite green
- [ ] Call `GET /api/v1/owner/admins` with owner JWT containing `view:admins` — 200
- [ ] Call `GET /api/v1/owner/admins` with owner JWT missing `view:admins` — 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)