### PR TITLE
Refactor middleware naming to verb-style conventions

### DIFF
--- a/apps/api/src/middleware/captcha/__tests__/captcha.test.ts
+++ b/apps/api/src/middleware/captcha/__tests__/captcha.test.ts
@@ -11,7 +11,7 @@ import { HttpStatus } from '@/net/http'
 import { captchaMiddleware } from '../captcha'
 import { invalidCaptchaTokens } from './captcha.mock'
 
-// Simple schema for test validation (mirrors what requestValidator would validate)
+// Simple schema for test validation (mirrors what validateBody would validate)
 const captchaSchema = z.object({
   captcha: z.object({
     token: z.string()

--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -17,8 +17,6 @@ export {
   generalRateLimiter
 } from './rate-limiter'
 
-export { requestValidator } from './request-validator'
-
 export { requirePermission } from './require-permission'
 
 export { secureHeadersMiddleware } from './secure-headers'
@@ -31,3 +29,5 @@ export {
 } from './size-limiter'
 
 export { teamAccessMiddleware } from './team-access'
+
+export { validateBody, validateParams, validateQuery } from './validate-request'

--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -28,6 +28,6 @@ export {
   generalRequestSizeLimiter
 } from './size-limiter'
 
-export { teamAccessMiddleware } from './team-access'
+export { requireTeamAccess } from './team-access'
 
 export { validateBody, validateParams, validateQuery } from './validate-request'

--- a/apps/api/src/middleware/request-validator/index.ts
+++ b/apps/api/src/middleware/request-validator/index.ts
@@ -1,1 +1,0 @@
-export { requestValidator } from './request-validator'

--- a/apps/api/src/middleware/team-access/__tests__/team-access.test.ts
+++ b/apps/api/src/middleware/team-access/__tests__/team-access.test.ts
@@ -9,7 +9,7 @@ import { onError } from '@/handlers'
 import HttpStatus from '@/net/http/status'
 import { Role, UserStatus } from '@/types'
 
-import { teamAccessMiddleware } from '../team-access'
+import { requireTeamAccess } from '../team-access'
 
 const mockTeamRepoFindMember = mock()
 
@@ -47,7 +47,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -74,7 +74,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -101,7 +101,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_2}`)
@@ -125,7 +125,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -147,7 +147,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_2}`)
@@ -168,7 +168,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -190,7 +190,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_2}`)
@@ -211,7 +211,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -229,7 +229,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -252,7 +252,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -278,7 +278,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
@@ -304,7 +304,7 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.use('/teams/:teamId', requireTeamAccess)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)

--- a/apps/api/src/middleware/team-access/index.ts
+++ b/apps/api/src/middleware/team-access/index.ts
@@ -1,1 +1,1 @@
-export { teamAccessMiddleware } from './team-access'
+export { requireTeamAccess } from './team-access'

--- a/apps/api/src/middleware/team-access/team-access.ts
+++ b/apps/api/src/middleware/team-access/team-access.ts
@@ -9,7 +9,7 @@ import { isAdmin } from '@/types'
 /**
  * Team access middleware - ensures user has access to the team.
  *
- * Note: teamId is already validated by requestValidator middleware
+ * Note: teamId is already validated by validateParams middleware
  *
  * TODO: Add Redis caching for team membership queries
  * Currently queries database on every request (~1-5ms per query).

--- a/apps/api/src/middleware/team-access/team-access.ts
+++ b/apps/api/src/middleware/team-access/team-access.ts
@@ -16,7 +16,7 @@ import { isAdmin } from '@/types'
  * With Redis cache: 80-95% hit rate, 20-50x faster response time.
  * See: https://github.com/SlavaMelanko/smela-back/issues/58
  */
-export const teamAccessMiddleware = createMiddleware<AppContext>(
+export const requireTeamAccess = createMiddleware<AppContext>(
   async (c, next) => {
     const teamId = c.req.param('teamId')!
     const { id: userId, role } = c.get('user')

--- a/apps/api/src/middleware/validate-request/__tests__/validate-request.test.ts
+++ b/apps/api/src/middleware/validate-request/__tests__/validate-request.test.ts
@@ -8,7 +8,7 @@ import { onError } from '@/handlers'
 import { HttpStatus } from '@/net/http'
 import { TOKEN_LENGTH } from '@/security/token'
 
-import { requestValidator } from '../request-validator'
+import { validateBody } from '../validate-request'
 
 describe('Request Validator Middleware', () => {
   it('should accept valid email and password together', async () => {
@@ -19,9 +19,7 @@ describe('Request Validator Middleware', () => {
 
     const app = new Hono()
     app.onError(onError)
-    app.post('/test', requestValidator('json', schema), c =>
-      c.json({ success: true })
-    )
+    app.post('/test', validateBody(schema), c => c.json({ success: true }))
 
     const response = await post(app, '/test', {
       email: 'user@example.com',
@@ -42,9 +40,7 @@ describe('Request Validator Middleware', () => {
 
     const app = new Hono()
     app.onError(onError)
-    app.post('/test', requestValidator('json', schema), c =>
-      c.json({ success: true })
-    )
+    app.post('/test', validateBody(schema), c => c.json({ success: true }))
 
     const response = await post(app, '/test', { email: 'user@example.com' })
 
@@ -72,9 +68,7 @@ describe('Request Validator Middleware', () => {
 
     const app = new Hono()
     app.onError(onError)
-    app.post('/test', requestValidator('json', schema), c =>
-      c.json({ success: true })
-    )
+    app.post('/test', validateBody(schema), c => c.json({ success: true }))
 
     const validToken = 'a'.repeat(TOKEN_LENGTH) // exactly 64 characters
     const tooLongToken = `${validToken}extra` // 69 characters

--- a/apps/api/src/middleware/validate-request/index.ts
+++ b/apps/api/src/middleware/validate-request/index.ts
@@ -1,0 +1,1 @@
+export { validateBody, validateParams, validateQuery } from './validate-request'

--- a/apps/api/src/middleware/validate-request/validate-request.ts
+++ b/apps/api/src/middleware/validate-request/validate-request.ts
@@ -6,7 +6,7 @@ import { zValidator } from '@hono/zod-validator'
 import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
 
-export const requestValidator = <
+const validate = <
   Target extends keyof ValidationTargets,
   Schema extends ZodType
 >(
@@ -22,3 +22,12 @@ export const requestValidator = <
       throw new AppError(ErrorCode.ValidationError, JSON.stringify(issues))
     }
   })
+
+export const validateBody = <Schema extends ZodType>(schema: Schema) =>
+  validate('json', schema)
+
+export const validateParams = <Schema extends ZodType>(schema: Schema) =>
+  validate('param', schema)
+
+export const validateQuery = <Schema extends ZodType>(schema: Schema) =>
+  validate('query', schema)

--- a/apps/api/src/routes/admin/teams/index.ts
+++ b/apps/api/src/routes/admin/teams/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateBody, validateQuery } from '@/middleware'
 
 import { createTeamHandler, getTeamsHandler } from './handler'
 import { createTeamBodySchema, getTeamsQuerySchema } from './schema'
@@ -11,12 +11,12 @@ export const adminTeamsRoute = new Hono<AppContext>()
 
 adminTeamsRoute.get(
   '/teams',
-  requestValidator('query', getTeamsQuerySchema),
+  validateQuery(getTeamsQuerySchema),
   getTeamsHandler
 )
 
 adminTeamsRoute.post(
   '/teams',
-  requestValidator('json', createTeamBodySchema),
+  validateBody(createTeamBodySchema),
   createTeamHandler
 )

--- a/apps/api/src/routes/admin/users/$id/index.ts
+++ b/apps/api/src/routes/admin/users/$id/index.ts
@@ -2,22 +2,18 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateBody, validateParams } from '@/middleware'
 
 import { getUserHandler, updateUserHandler } from './handler'
 import { updateUserBodySchema, userIdParamsSchema } from './schema'
 
 export const adminUserByIdRoute = new Hono<AppContext>()
 
-adminUserByIdRoute.get(
-  '/',
-  requestValidator('param', userIdParamsSchema),
-  getUserHandler
-)
+adminUserByIdRoute.get('/', validateParams(userIdParamsSchema), getUserHandler)
 
 adminUserByIdRoute.patch(
   '/',
-  requestValidator('param', userIdParamsSchema),
-  requestValidator('json', updateUserBodySchema),
+  validateParams(userIdParamsSchema),
+  validateBody(updateUserBodySchema),
   updateUserHandler
 )

--- a/apps/api/src/routes/admin/users/index.ts
+++ b/apps/api/src/routes/admin/users/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateQuery } from '@/middleware'
 
 import { adminUserByIdRoute } from './$id'
 import { getUsersHandler } from './handler'
@@ -12,7 +12,7 @@ export const adminUsersRoute = new Hono<AppContext>()
 
 adminUsersRoute.get(
   '/users',
-  requestValidator('query', getUsersQuerySchema),
+  validateQuery(getUsersQuerySchema),
   getUsersHandler
 )
 

--- a/apps/api/src/routes/auth/accept-invite/index.ts
+++ b/apps/api/src/routes/auth/accept-invite/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateBody } from '@/middleware'
 
 import { acceptInviteHandler } from './handler'
 import { acceptInviteBodySchema } from './schema'
@@ -11,6 +11,6 @@ export const acceptInviteRoute = new Hono<AppContext>()
 
 acceptInviteRoute.post(
   '/accept-invite',
-  requestValidator('json', acceptInviteBodySchema),
+  validateBody(acceptInviteBodySchema),
   acceptInviteHandler
 )

--- a/apps/api/src/routes/auth/check-invite/index.ts
+++ b/apps/api/src/routes/auth/check-invite/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateQuery } from '@/middleware'
 
 import { checkInviteHandler } from './handler'
 import { checkInviteQuerySchema } from './schema'
@@ -11,6 +11,6 @@ export const checkInviteRoute = new Hono<AppContext>()
 
 checkInviteRoute.get(
   '/check-invite',
-  requestValidator('query', checkInviteQuerySchema),
+  validateQuery(checkInviteQuerySchema),
   checkInviteHandler
 )

--- a/apps/api/src/routes/auth/login/index.ts
+++ b/apps/api/src/routes/auth/login/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { captchaMiddleware, requestValidator } from '@/middleware'
+import { captchaMiddleware, validateBody } from '@/middleware'
 
 import { loginHandler } from './handler'
 import { loginBodySchema } from './schema'
@@ -11,7 +11,7 @@ export const loginRoute = new Hono<AppContext>()
 
 loginRoute.post(
   '/login',
-  requestValidator('json', loginBodySchema),
+  validateBody(loginBodySchema),
   captchaMiddleware(),
   loginHandler
 )

--- a/apps/api/src/routes/auth/request-password-reset/index.ts
+++ b/apps/api/src/routes/auth/request-password-reset/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { captchaMiddleware, requestValidator } from '@/middleware'
+import { captchaMiddleware, validateBody } from '@/middleware'
 
 import { requestPasswordResetHandler } from './handler'
 import { requestPasswordResetBodySchema } from './schema'
@@ -11,7 +11,7 @@ export const requestPasswordResetRoute = new Hono<AppContext>()
 
 requestPasswordResetRoute.post(
   '/request-password-reset',
-  requestValidator('json', requestPasswordResetBodySchema),
+  validateBody(requestPasswordResetBodySchema),
   captchaMiddleware(),
   requestPasswordResetHandler
 )

--- a/apps/api/src/routes/auth/resend-verification-email/index.ts
+++ b/apps/api/src/routes/auth/resend-verification-email/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { captchaMiddleware, requestValidator } from '@/middleware'
+import { captchaMiddleware, validateBody } from '@/middleware'
 
 import { resendVerificationEmailHandler } from './handler'
 import { resendVerificationEmailBodySchema } from './schema'
@@ -11,7 +11,7 @@ export const resendVerificationEmailRoute = new Hono<AppContext>()
 
 resendVerificationEmailRoute.post(
   '/resend-verification-email',
-  requestValidator('json', resendVerificationEmailBodySchema),
+  validateBody(resendVerificationEmailBodySchema),
   captchaMiddleware(),
   resendVerificationEmailHandler
 )

--- a/apps/api/src/routes/auth/reset-password/index.ts
+++ b/apps/api/src/routes/auth/reset-password/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateBody } from '@/middleware'
 
 import { resetPasswordHandler } from './handler'
 import { resetPasswordBodySchema } from './schema'
@@ -11,6 +11,6 @@ export const resetPasswordRoute = new Hono<AppContext>()
 
 resetPasswordRoute.post(
   '/reset-password',
-  requestValidator('json', resetPasswordBodySchema),
+  validateBody(resetPasswordBodySchema),
   resetPasswordHandler
 )

--- a/apps/api/src/routes/auth/signup/index.ts
+++ b/apps/api/src/routes/auth/signup/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { captchaMiddleware, requestValidator } from '@/middleware'
+import { captchaMiddleware, validateBody } from '@/middleware'
 
 import { signupHandler } from './handler'
 import { signupBodySchema } from './schema'
@@ -11,7 +11,7 @@ export const signupRoute = new Hono<AppContext>()
 
 signupRoute.post(
   '/signup',
-  requestValidator('json', signupBodySchema),
+  validateBody(signupBodySchema),
   captchaMiddleware(),
   signupHandler
 )

--- a/apps/api/src/routes/auth/verify-email/index.ts
+++ b/apps/api/src/routes/auth/verify-email/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateBody } from '@/middleware'
 
 import { verifyEmailHandler } from './handler'
 import { verifyEmailBodySchema } from './schema'
@@ -11,6 +11,6 @@ export const verifyEmailRoute = new Hono<AppContext>()
 
 verifyEmailRoute.post(
   '/verify-email',
-  requestValidator('json', verifyEmailBodySchema),
+  validateBody(verifyEmailBodySchema),
   verifyEmailHandler
 )

--- a/apps/api/src/routes/owner/admins/$id/index.ts
+++ b/apps/api/src/routes/owner/admins/$id/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator, requirePermission } from '@/middleware'
+import { requirePermission, validateBody, validateParams } from '@/middleware'
 import Permission from '@/types/permission'
 
 import {
@@ -18,29 +18,29 @@ export const ownerAdminByIdRoute = new Hono<AppContext>()
 
 ownerAdminByIdRoute.get(
   '/',
-  requestValidator('param', adminIdParamsSchema),
+  validateParams(adminIdParamsSchema),
   requirePermission(Permission.ViewAdmins),
   getAdminHandler
 )
 
 ownerAdminByIdRoute.patch(
   '/',
-  requestValidator('param', adminIdParamsSchema),
-  requestValidator('json', updateAdminBodySchema),
+  validateParams(adminIdParamsSchema),
+  validateBody(updateAdminBodySchema),
   requirePermission(Permission.ManageAdmins),
   updateAdminHandler
 )
 
 ownerAdminByIdRoute.post(
   '/resend-invite',
-  requestValidator('param', adminIdParamsSchema),
+  validateParams(adminIdParamsSchema),
   requirePermission(Permission.ManageAdmins),
   resendAdminInviteHandler
 )
 
 ownerAdminByIdRoute.post(
   '/cancel-invite',
-  requestValidator('param', adminIdParamsSchema),
+  validateParams(adminIdParamsSchema),
   requirePermission(Permission.ManageAdmins),
   cancelAdminInviteHandler
 )

--- a/apps/api/src/routes/owner/admins/$id/permissions/index.ts
+++ b/apps/api/src/routes/owner/admins/$id/permissions/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator, requirePermission } from '@/middleware'
+import { requirePermission, validateBody, validateParams } from '@/middleware'
 import Permission from '@/types/permission'
 
 import {
@@ -15,15 +15,15 @@ export const ownerAdminPermissionsRoute = new Hono<AppContext>()
 
 ownerAdminPermissionsRoute.get(
   '/',
-  requestValidator('param', adminIdParamsSchema),
+  validateParams(adminIdParamsSchema),
   requirePermission(Permission.ViewAdmins),
   getAdminPermissionsHandler
 )
 
 ownerAdminPermissionsRoute.patch(
   '/',
-  requestValidator('param', adminIdParamsSchema),
-  requestValidator('json', updateAdminPermissionsBodySchema),
+  validateParams(adminIdParamsSchema),
+  validateBody(updateAdminPermissionsBodySchema),
   requirePermission(Permission.ManageAdmins),
   updateAdminPermissionsHandler
 )

--- a/apps/api/src/routes/owner/admins/index.ts
+++ b/apps/api/src/routes/owner/admins/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator, requirePermission } from '@/middleware'
+import { requirePermission, validateBody, validateQuery } from '@/middleware'
 import Permission from '@/types/permission'
 
 import { ownerAdminByIdRoute } from './$id'
@@ -17,14 +17,14 @@ export const ownerAdminsRoute = new Hono<AppContext>()
 
 ownerAdminsRoute.get(
   '/admins',
-  requestValidator('query', getAdminsQuerySchema),
+  validateQuery(getAdminsQuerySchema),
   requirePermission(Permission.ViewAdmins),
   getAdminsHandler
 )
 
 ownerAdminsRoute.post(
   '/admins',
-  requestValidator('json', createAdminBodySchema),
+  validateBody(createAdminBodySchema),
   requirePermission(Permission.ManageAdmins),
   createAdminHandler
 )

--- a/apps/api/src/routes/user/me/index.ts
+++ b/apps/api/src/routes/user/me/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator } from '@/middleware'
+import { validateBody } from '@/middleware'
 
 import { changePasswordHandler, getMeHandler, updateMeHandler } from './handler'
 import { changePasswordSchema, updateProfileSchema } from './schema'
@@ -11,14 +11,10 @@ export const meRoute = new Hono<AppContext>()
 
 meRoute.get('/me', getMeHandler)
 
-meRoute.patch(
-  '/me',
-  requestValidator('json', updateProfileSchema),
-  updateMeHandler
-)
+meRoute.patch('/me', validateBody(updateProfileSchema), updateMeHandler)
 
 meRoute.patch(
   '/me/password',
-  requestValidator('json', changePasswordSchema),
+  validateBody(changePasswordSchema),
   changePasswordHandler
 )

--- a/apps/api/src/routes/user/teams/$id/index.ts
+++ b/apps/api/src/routes/user/teams/$id/index.ts
@@ -2,11 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import {
-  teamAccessMiddleware,
-  validateBody,
-  validateParams
-} from '@/middleware'
+import { requireTeamAccess, validateBody, validateParams } from '@/middleware'
 
 import { getTeamHandler, updateTeamHandler } from './handler'
 import { teamsMembersRoute } from './members'
@@ -17,7 +13,7 @@ export const teamByIdRoute = new Hono<AppContext>()
 teamByIdRoute.get(
   '/',
   validateParams(teamIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   getTeamHandler
 )
 
@@ -25,7 +21,7 @@ teamByIdRoute.patch(
   '/',
   validateParams(teamIdParamsSchema),
   validateBody(updateTeamBodySchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   updateTeamHandler
 )
 

--- a/apps/api/src/routes/user/teams/$id/index.ts
+++ b/apps/api/src/routes/user/teams/$id/index.ts
@@ -2,7 +2,11 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator, teamAccessMiddleware } from '@/middleware'
+import {
+  teamAccessMiddleware,
+  validateBody,
+  validateParams
+} from '@/middleware'
 
 import { getTeamHandler, updateTeamHandler } from './handler'
 import { teamsMembersRoute } from './members'
@@ -12,15 +16,15 @@ export const teamByIdRoute = new Hono<AppContext>()
 
 teamByIdRoute.get(
   '/',
-  requestValidator('param', teamIdParamsSchema),
+  validateParams(teamIdParamsSchema),
   teamAccessMiddleware,
   getTeamHandler
 )
 
 teamByIdRoute.patch(
   '/',
-  requestValidator('param', teamIdParamsSchema),
-  requestValidator('json', updateTeamBodySchema),
+  validateParams(teamIdParamsSchema),
+  validateBody(updateTeamBodySchema),
   teamAccessMiddleware,
   updateTeamHandler
 )

--- a/apps/api/src/routes/user/teams/$id/members/$id/index.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/index.ts
@@ -2,7 +2,11 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator, teamAccessMiddleware } from '@/middleware'
+import {
+  teamAccessMiddleware,
+  validateBody,
+  validateParams
+} from '@/middleware'
 
 import {
   cancelMemberInviteHandler,
@@ -17,36 +21,36 @@ export const teamsMemberByIdRoute = new Hono<AppContext>()
 
 teamsMemberByIdRoute.get(
   '/',
-  requestValidator('param', memberIdParamsSchema),
+  validateParams(memberIdParamsSchema),
   teamAccessMiddleware,
   getTeamMemberHandler
 )
 
 teamsMemberByIdRoute.patch(
   '/',
-  requestValidator('param', memberIdParamsSchema),
-  requestValidator('json', updateTeamMemberBodySchema),
+  validateParams(memberIdParamsSchema),
+  validateBody(updateTeamMemberBodySchema),
   teamAccessMiddleware,
   updateTeamMemberHandler
 )
 
 teamsMemberByIdRoute.delete(
   '/',
-  requestValidator('param', memberIdParamsSchema),
+  validateParams(memberIdParamsSchema),
   teamAccessMiddleware,
   removeTeamMemberHandler
 )
 
 teamsMemberByIdRoute.post(
   '/resend-invite',
-  requestValidator('param', memberIdParamsSchema),
+  validateParams(memberIdParamsSchema),
   teamAccessMiddleware,
   resendMemberInviteHandler
 )
 
 teamsMemberByIdRoute.post(
   '/cancel-invite',
-  requestValidator('param', memberIdParamsSchema),
+  validateParams(memberIdParamsSchema),
   teamAccessMiddleware,
   cancelMemberInviteHandler
 )

--- a/apps/api/src/routes/user/teams/$id/members/$id/index.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/index.ts
@@ -2,11 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import {
-  teamAccessMiddleware,
-  validateBody,
-  validateParams
-} from '@/middleware'
+import { requireTeamAccess, validateBody, validateParams } from '@/middleware'
 
 import {
   cancelMemberInviteHandler,
@@ -22,7 +18,7 @@ export const teamsMemberByIdRoute = new Hono<AppContext>()
 teamsMemberByIdRoute.get(
   '/',
   validateParams(memberIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   getTeamMemberHandler
 )
 
@@ -30,27 +26,27 @@ teamsMemberByIdRoute.patch(
   '/',
   validateParams(memberIdParamsSchema),
   validateBody(updateTeamMemberBodySchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   updateTeamMemberHandler
 )
 
 teamsMemberByIdRoute.delete(
   '/',
   validateParams(memberIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   removeTeamMemberHandler
 )
 
 teamsMemberByIdRoute.post(
   '/resend-invite',
   validateParams(memberIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   resendMemberInviteHandler
 )
 
 teamsMemberByIdRoute.post(
   '/cancel-invite',
   validateParams(memberIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   cancelMemberInviteHandler
 )

--- a/apps/api/src/routes/user/teams/$id/members/index.ts
+++ b/apps/api/src/routes/user/teams/$id/members/index.ts
@@ -2,7 +2,11 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { requestValidator, teamAccessMiddleware } from '@/middleware'
+import {
+  teamAccessMiddleware,
+  validateBody,
+  validateParams
+} from '@/middleware'
 
 import { teamsMemberByIdRoute } from './$id'
 import {
@@ -16,22 +20,22 @@ export const teamsMembersRoute = new Hono<AppContext>()
 
 teamsMembersRoute.get(
   '/',
-  requestValidator('param', teamIdParamsSchema),
+  validateParams(teamIdParamsSchema),
   teamAccessMiddleware,
   getTeamMembersHandler
 )
 
 teamsMembersRoute.post(
   '/',
-  requestValidator('param', teamIdParamsSchema),
-  requestValidator('json', inviteMemberBodySchema),
+  validateParams(teamIdParamsSchema),
+  validateBody(inviteMemberBodySchema),
   teamAccessMiddleware,
   createMemberHandler
 )
 
 teamsMembersRoute.get(
   '/default-permissions',
-  requestValidator('param', teamIdParamsSchema),
+  validateParams(teamIdParamsSchema),
   teamAccessMiddleware,
   getMemberDefaultPermissionsHandler
 )

--- a/apps/api/src/routes/user/teams/$id/members/index.ts
+++ b/apps/api/src/routes/user/teams/$id/members/index.ts
@@ -2,11 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import {
-  teamAccessMiddleware,
-  validateBody,
-  validateParams
-} from '@/middleware'
+import { requireTeamAccess, validateBody, validateParams } from '@/middleware'
 
 import { teamsMemberByIdRoute } from './$id'
 import {
@@ -21,7 +17,7 @@ export const teamsMembersRoute = new Hono<AppContext>()
 teamsMembersRoute.get(
   '/',
   validateParams(teamIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   getTeamMembersHandler
 )
 
@@ -29,14 +25,14 @@ teamsMembersRoute.post(
   '/',
   validateParams(teamIdParamsSchema),
   validateBody(inviteMemberBodySchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   createMemberHandler
 )
 
 teamsMembersRoute.get(
   '/default-permissions',
   validateParams(teamIdParamsSchema),
-  teamAccessMiddleware,
+  requireTeamAccess,
   getMemberDefaultPermissionsHandler
 )
 

--- a/apps/api/src/routes/validated-ctx.ts
+++ b/apps/api/src/routes/validated-ctx.ts
@@ -3,23 +3,23 @@
  *
  * When routes are inline, Hono infers types through the middleware chain:
  * ```typescript
- * route.post('/signup', requestValidator('json', schema), async (c) => {
+ * route.post('/signup', validateBody(schema), async (c) => {
  *   const payload = c.req.valid('json') // ✓ TypeScript infers 'json' is valid
  * })
  * ```
  *
  * When handlers are in separate files, the type chain breaks:
  * ```typescript
- * // handler.ts - TypeScript has no idea about requestValidator
+ * // handler.ts - TypeScript has no idea about validateBody
  * const handler = async (c) => {
  *   c.req.valid('json') // ✗ Error: 'json' not assignable to 'never'
  * }
  *
  * // index.ts - Type info doesn't flow back to handler.ts
- * route.post('/signup', requestValidator('json', schema), handler)
+ * route.post('/signup', validateBody(schema), handler)
  * ```
  *
- * These types manually declare what `requestValidator` would have inferred:
+ * These types manually declare what `validateBody` would have inferred:
  * ```typescript
  * const handler = async (c: ValidatedJsonCtx<SignupBody>) => {
  *   c.req.valid('json') // ✓ Now TypeScript knows 'json' is valid


### PR DESCRIPTION
## Changes

- Replace generic `requestValidator(target, schema)` with three dedicated helpers: `validateBody`, `validateParams`, `validateQuery`
- Rename `middleware/request-validator/` directory to `middleware/validate-request/`
- Rename `teamAccessMiddleware` to `requireTeamAccess` — consistent with `requirePermission` pattern
- Update barrel export in `middleware/index.ts`
- Migrate all 49 call sites across 17 route files to use the new validation helpers
- Update test files and stale comment references throughout

## Why

Both `requestValidator` (noun) and `teamAccessMiddleware` (noun + redundant suffix) were inconsistent with the verb-style middleware convention already established by `requirePermission`. The new names are shorter, self-documenting, and remove the string target argument at every validation call site.