### PR TITLE
Enhance team access middleware with context optimization

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -1,7 +1,11 @@
+import type { TeamMemberDetails, TeamWithMemberCount } from '@/data'
 import type { UserClaims } from '@/security/jwt'
 
 export interface Variables {
   user: UserClaims
+  team: TeamWithMemberCount | undefined
+  currentUser: TeamMemberDetails | undefined
+  targetMember: TeamMemberDetails | undefined
 }
 
 export interface AppContext {

--- a/apps/api/src/middleware/team-access/__tests__/team-access.test.ts
+++ b/apps/api/src/middleware/team-access/__tests__/team-access.test.ts
@@ -11,10 +11,12 @@ import { Role, UserStatus } from '@/types'
 
 import { requireTeamAccess } from '../team-access'
 
+const mockTeamRepoFind = mock()
 const mockTeamRepoFindMember = mock()
 
 void mock.module('@/data', () => ({
   teamRepo: {
+    find: mockTeamRepoFind,
     findMember: mockTeamRepoFindMember
   }
 }))
@@ -22,7 +24,9 @@ void mock.module('@/data', () => ({
 const makeApp = (role: Role, userId: string) => {
   const app = new Hono<AppContext>()
   app.onError(onError)
-  app.use('/teams/:teamId', async (c, next) => {
+
+  // Setup user context for all routes
+  app.use('*', async (c, next) => {
     c.set('user', {
       id: userId,
       email: 'user@example.com',
@@ -31,23 +35,56 @@ const makeApp = (role: Role, userId: string) => {
     })
     await next()
   })
+
+  // Team-only routes
   app.use('/teams/:teamId', requireTeamAccess)
-  app.get('/teams/:teamId', c => c.json({ message: 'success' }))
+  app.get('/teams/:teamId', c => c.json({ message: 'team success' }))
+
+  // Member-specific routes
+  app.use('/teams/:teamId/members/:memberId', requireTeamAccess)
+  app.get('/teams/:teamId/members/:memberId', c =>
+    c.json({ message: 'member success' })
+  )
 
   return app
 }
 
 describe('Team Access Middleware', () => {
   beforeEach(() => {
+    mockTeamRepoFind.mockClear()
     mockTeamRepoFindMember.mockClear()
+
+    // Default: team exists
+    mockTeamRepoFind.mockImplementation(async () => ({
+      id: testUuids.TEAM_1,
+      name: 'Test Team',
+      memberCount: 5
+    }))
   })
 
-  describe('Regular User Access', () => {
-    it('should allow access when user has valid team membership', async () => {
+  describe('Team Existence Validation', () => {
+    it('should block all users when team does not exist', async () => {
+      mockTeamRepoFind.mockImplementation(async () => undefined)
+
+      const adminRes = await makeApp(Role.Admin, testUuids.ADMIN_1).request(
+        `/teams/${testUuids.NON_EXISTENT}`
+      )
+      const userRes = await makeApp(Role.User, testUuids.USER_1).request(
+        `/teams/${testUuids.NON_EXISTENT}`
+      )
+
+      expect(adminRes.status).toBe(HttpStatus.NOT_FOUND)
+      expect(userRes.status).toBe(HttpStatus.NOT_FOUND)
+      expect((await adminRes.json()).code).toBe(ErrorCode.NotFound)
+      expect((await userRes.json()).code).toBe(ErrorCode.NotFound)
+    })
+  })
+
+  describe('Regular User Access - Team Routes', () => {
+    it('should allow access when user is team member', async () => {
       mockTeamRepoFindMember.mockImplementation(async () => ({
         userId: testUuids.USER_1,
-        teamId: testUuids.TEAM_1,
-        joinedAt: new Date()
+        teamId: testUuids.TEAM_1
       }))
 
       const res = await makeApp(Role.User, testUuids.USER_1).request(
@@ -55,15 +92,15 @@ describe('Team Access Middleware', () => {
       )
 
       expect(res.status).toBe(HttpStatus.OK)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledTimes(1)
+      expect(mockTeamRepoFind).toHaveBeenCalledWith(testUuids.TEAM_1)
       expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
         testUuids.TEAM_1,
         testUuids.USER_1
       )
-      expect((await res.json()).message).toBe('success')
+      expect((await res.json()).message).toBe('team success')
     })
 
-    it('should throw Forbidden when user has no team membership', async () => {
+    it('should block access when user is not team member', async () => {
       mockTeamRepoFindMember.mockImplementation(async () => undefined)
 
       const res = await makeApp(Role.User, testUuids.USER_1).request(
@@ -71,45 +108,111 @@ describe('Team Access Middleware', () => {
       )
 
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
-        testUuids.TEAM_1,
-        testUuids.USER_1
-      )
       expect((await res.json()).code).toBe(ErrorCode.Forbidden)
     })
   })
 
-  describe('Admin and Owner Access', () => {
-    it('should allow Admin access without querying the database', async () => {
+  describe('Regular User Access - Member Routes', () => {
+    it('should allow access when both user and target are team members', async () => {
+      mockTeamRepoFindMember.mockImplementation(async (teamId, userId) => ({
+        userId,
+        teamId,
+        joinedAt: new Date()
+      }))
+
+      const res = await makeApp(Role.User, testUuids.USER_1).request(
+        `/teams/${testUuids.TEAM_1}/members/${testUuids.USER_2}`
+      )
+
+      expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFindMember).toHaveBeenCalledTimes(2) // Parallel calls
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
+        testUuids.TEAM_1,
+        testUuids.USER_1
+      )
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
+        testUuids.TEAM_1,
+        testUuids.USER_2
+      )
+    })
+
+    it('should block access when user is not team member', async () => {
+      mockTeamRepoFindMember.mockImplementation(async (teamId, userId) => {
+        return userId === testUuids.USER_1 ? undefined : { userId, teamId }
+      })
+
+      const res = await makeApp(Role.User, testUuids.USER_1).request(
+        `/teams/${testUuids.TEAM_1}/members/${testUuids.USER_2}`
+      )
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      expect((await res.json()).code).toBe(ErrorCode.Forbidden)
+    })
+
+    it('should block access when target member is not in team', async () => {
+      mockTeamRepoFindMember.mockImplementation(async (teamId, userId) => {
+        return userId === testUuids.USER_2 ? undefined : { userId, teamId }
+      })
+
+      const res = await makeApp(Role.User, testUuids.USER_1).request(
+        `/teams/${testUuids.TEAM_1}/members/${testUuids.USER_2}`
+      )
+
+      expect(res.status).toBe(HttpStatus.NOT_FOUND)
+      expect((await res.json()).code).toBe(ErrorCode.NotFound)
+    })
+  })
+
+  describe('Admin Access', () => {
+    it('should allow admin access to team routes', async () => {
       const res = await makeApp(Role.Admin, testUuids.ADMIN_1).request(
         `/teams/${testUuids.TEAM_1}`
       )
 
       expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFind).toHaveBeenCalledWith(testUuids.TEAM_1)
       expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
     })
 
-    it('should allow Owner access without querying the database', async () => {
+    it('should allow admin access to member routes when member exists', async () => {
+      mockTeamRepoFindMember.mockImplementation(async () => ({
+        userId: testUuids.USER_1,
+        teamId: testUuids.TEAM_1
+      }))
+
+      const res = await makeApp(Role.Admin, testUuids.ADMIN_1).request(
+        `/teams/${testUuids.TEAM_1}/members/${testUuids.USER_1}`
+      )
+
+      expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFind).toHaveBeenCalledWith(testUuids.TEAM_1)
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
+        testUuids.TEAM_1,
+        testUuids.USER_1
+      )
+    })
+
+    it('should block admin when target member not in team', async () => {
+      mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+      const res = await makeApp(Role.Admin, testUuids.ADMIN_1).request(
+        `/teams/${testUuids.TEAM_1}/members/${testUuids.USER_1}`
+      )
+
+      expect(res.status).toBe(HttpStatus.NOT_FOUND)
+      expect((await res.json()).code).toBe(ErrorCode.NotFound)
+    })
+  })
+
+  describe('Owner Access', () => {
+    it('should allow owner access identical to admin', async () => {
       const res = await makeApp(Role.Owner, testUuids.OWNER_1).request(
         `/teams/${testUuids.TEAM_1}`
       )
 
       expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFind).toHaveBeenCalledWith(testUuids.TEAM_1)
       expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('Error Handling', () => {
-    it('should propagate database errors', async () => {
-      mockTeamRepoFindMember.mockImplementation(async () => {
-        throw new Error('Database connection failed')
-      })
-
-      const res = await makeApp(Role.User, testUuids.USER_1).request(
-        `/teams/${testUuids.TEAM_1}`
-      )
-
-      expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
     })
   })
 })

--- a/apps/api/src/middleware/team-access/team-access.ts
+++ b/apps/api/src/middleware/team-access/team-access.ts
@@ -24,7 +24,7 @@ import { isAdmin } from '@/types'
 export const requireTeamAccess = createMiddleware<AppContext>(
   async (c, next) => {
     const teamId = c.req.param('teamId')!
-    const memberId = c.req.param('memberId') // Optional - only on member-specific routes
+    const memberId = c.req.param('memberId')
     const { id: currentUserId, role } = c.get('user')
 
     // Step 1: Always verify team exists (for all users)
@@ -32,6 +32,8 @@ export const requireTeamAccess = createMiddleware<AppContext>(
     if (!team) {
       throw new AppError(ErrorCode.NotFound, 'Team not found')
     }
+
+    c.set('team', team)
 
     // Step 2: Role-based member validation
     if (isAdmin(role)) {
@@ -41,31 +43,36 @@ export const requireTeamAccess = createMiddleware<AppContext>(
         if (!targetMember) {
           throw new AppError(ErrorCode.NotFound, 'Member not found')
         }
+        c.set('targetMember', targetMember)
       }
+      c.set('currentUser', undefined)
     } else {
       // Regular users: Must be team members + validate target member (if applicable)
       if (memberId) {
         // Member-specific routes: validate both current user and target member
-        const [currentUserMember, targetMember] = await Promise.all([
+        const [currentUser, targetMember] = await Promise.all([
           teamRepo.findMember(teamId, currentUserId),
           teamRepo.findMember(teamId, memberId)
         ])
 
-        if (!currentUserMember) {
+        if (!currentUser) {
           throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
         }
         if (!targetMember) {
           throw new AppError(ErrorCode.NotFound, 'Member not found')
         }
+
+        c.set('currentUser', currentUser)
+        c.set('targetMember', targetMember)
       } else {
         // Team-only routes: validate current user is team member
-        const currentUserMember = await teamRepo.findMember(
-          teamId,
-          currentUserId
-        )
-        if (!currentUserMember) {
+        const currentUser = await teamRepo.findMember(teamId, currentUserId)
+        if (!currentUser) {
           throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
         }
+
+        c.set('currentUser', currentUser)
+        c.set('targetMember', undefined)
       }
     }
 

--- a/apps/api/src/middleware/team-access/team-access.ts
+++ b/apps/api/src/middleware/team-access/team-access.ts
@@ -24,12 +24,11 @@ import { isAdmin } from '@/types'
  * Note: teamId is already validated by validateParams middleware
  */
 
-const resolveAdminContext = async (
+const handleAdminAccess = async (
   c: Context<AppContext>,
   teamId: string,
   memberId: string | undefined
 ) => {
-  c.set('currentUser', undefined)
   if (!memberId) {
     return
   }
@@ -38,10 +37,11 @@ const resolveAdminContext = async (
   if (!targetMember) {
     throw new AppError(ErrorCode.NotFound, 'Member not found')
   }
+
   c.set('targetMember', targetMember)
 }
 
-const resolveUserContext = async (
+const handleUserAccess = async (
   c: Context<AppContext>,
   teamId: string,
   currentUserId: string,
@@ -69,7 +69,6 @@ const resolveUserContext = async (
     }
 
     c.set('currentUser', currentUser)
-    c.set('targetMember', undefined)
   }
 }
 
@@ -87,9 +86,9 @@ export const requireTeamAccess = createMiddleware<AppContext>(
     c.set('team', team)
 
     if (isAdmin(role)) {
-      await resolveAdminContext(c, teamId, memberId)
+      await handleAdminAccess(c, teamId, memberId)
     } else {
-      await resolveUserContext(c, teamId, currentUserId, memberId)
+      await handleUserAccess(c, teamId, currentUserId, memberId)
     }
 
     return next()

--- a/apps/api/src/middleware/team-access/team-access.ts
+++ b/apps/api/src/middleware/team-access/team-access.ts
@@ -1,3 +1,5 @@
+import type { Context } from 'hono'
+
 import { createMiddleware } from 'hono/factory'
 
 import type { AppContext } from '@/context'
@@ -21,13 +23,62 @@ import { isAdmin } from '@/types'
  *
  * Note: teamId is already validated by validateParams middleware
  */
+
+const resolveAdminContext = async (
+  c: Context<AppContext>,
+  teamId: string,
+  memberId: string | undefined
+) => {
+  c.set('currentUser', undefined)
+  if (!memberId) {
+    return
+  }
+
+  const targetMember = await teamRepo.findMember(teamId, memberId)
+  if (!targetMember) {
+    throw new AppError(ErrorCode.NotFound, 'Member not found')
+  }
+  c.set('targetMember', targetMember)
+}
+
+const resolveUserContext = async (
+  c: Context<AppContext>,
+  teamId: string,
+  currentUserId: string,
+  memberId: string | undefined
+) => {
+  if (memberId) {
+    const [currentUser, targetMember] = await Promise.all([
+      teamRepo.findMember(teamId, currentUserId),
+      teamRepo.findMember(teamId, memberId)
+    ])
+
+    if (!currentUser) {
+      throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
+    }
+    if (!targetMember) {
+      throw new AppError(ErrorCode.NotFound, 'Member not found')
+    }
+
+    c.set('currentUser', currentUser)
+    c.set('targetMember', targetMember)
+  } else {
+    const currentUser = await teamRepo.findMember(teamId, currentUserId)
+    if (!currentUser) {
+      throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
+    }
+
+    c.set('currentUser', currentUser)
+    c.set('targetMember', undefined)
+  }
+}
+
 export const requireTeamAccess = createMiddleware<AppContext>(
   async (c, next) => {
     const teamId = c.req.param('teamId')!
     const memberId = c.req.param('memberId')
     const { id: currentUserId, role } = c.get('user')
 
-    // Step 1: Always verify team exists (for all users)
     const team = await teamRepo.find(teamId)
     if (!team) {
       throw new AppError(ErrorCode.NotFound, 'Team not found')
@@ -35,45 +86,10 @@ export const requireTeamAccess = createMiddleware<AppContext>(
 
     c.set('team', team)
 
-    // Step 2: Role-based member validation
     if (isAdmin(role)) {
-      // Admins: Only validate target member exists (if applicable)
-      if (memberId) {
-        const targetMember = await teamRepo.findMember(teamId, memberId)
-        if (!targetMember) {
-          throw new AppError(ErrorCode.NotFound, 'Member not found')
-        }
-        c.set('targetMember', targetMember)
-      }
-      c.set('currentUser', undefined)
+      await resolveAdminContext(c, teamId, memberId)
     } else {
-      // Regular users: Must be team members + validate target member (if applicable)
-      if (memberId) {
-        // Member-specific routes: validate both current user and target member
-        const [currentUser, targetMember] = await Promise.all([
-          teamRepo.findMember(teamId, currentUserId),
-          teamRepo.findMember(teamId, memberId)
-        ])
-
-        if (!currentUser) {
-          throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
-        }
-        if (!targetMember) {
-          throw new AppError(ErrorCode.NotFound, 'Member not found')
-        }
-
-        c.set('currentUser', currentUser)
-        c.set('targetMember', targetMember)
-      } else {
-        // Team-only routes: validate current user is team member
-        const currentUser = await teamRepo.findMember(teamId, currentUserId)
-        if (!currentUser) {
-          throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
-        }
-
-        c.set('currentUser', currentUser)
-        c.set('targetMember', undefined)
-      }
+      await resolveUserContext(c, teamId, currentUserId, memberId)
     }
 
     return next()

--- a/apps/api/src/middleware/team-access/team-access.ts
+++ b/apps/api/src/middleware/team-access/team-access.ts
@@ -13,23 +13,60 @@ import { isAdmin } from '@/types'
  * 1. First: requirePermission with either Permission.ViewTeams or Permission.ManageTeams
  * 2. Then: requireTeamAccess (this middleware)
  *
+ * Logic:
+ * - Always validates team existence
+ * - For routes with memberId: validates target member exists in team
+ * - For admins: only validates team/member existence (permissions already checked)
+ * - For regular users: validates both current user AND target member access
+ *
  * Note: teamId is already validated by validateParams middleware
  */
 export const requireTeamAccess = createMiddleware<AppContext>(
   async (c, next) => {
     const teamId = c.req.param('teamId')!
-    const { id: userId, role } = c.get('user')
+    const memberId = c.req.param('memberId') // Optional - only on member-specific routes
+    const { id: currentUserId, role } = c.get('user')
 
-    // Admins bypass team membership check
-    if (isAdmin(role)) {
-      return next()
+    // Step 1: Always verify team exists (for all users)
+    const team = await teamRepo.find(teamId)
+    if (!team) {
+      throw new AppError(ErrorCode.NotFound, 'Team not found')
     }
 
-    // Regular users must be team members
-    const membership = await teamRepo.findMember(teamId, userId)
+    // Step 2: Role-based member validation
+    if (isAdmin(role)) {
+      // Admins: Only validate target member exists (if applicable)
+      if (memberId) {
+        const targetMember = await teamRepo.findMember(teamId, memberId)
+        if (!targetMember) {
+          throw new AppError(ErrorCode.NotFound, 'Member not found')
+        }
+      }
+    } else {
+      // Regular users: Must be team members + validate target member (if applicable)
+      if (memberId) {
+        // Member-specific routes: validate both current user and target member
+        const [currentUserMember, targetMember] = await Promise.all([
+          teamRepo.findMember(teamId, currentUserId),
+          teamRepo.findMember(teamId, memberId)
+        ])
 
-    if (!membership) {
-      throw new AppError(ErrorCode.Forbidden)
+        if (!currentUserMember) {
+          throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
+        }
+        if (!targetMember) {
+          throw new AppError(ErrorCode.NotFound, 'Member not found')
+        }
+      } else {
+        // Team-only routes: validate current user is team member
+        const currentUserMember = await teamRepo.findMember(
+          teamId,
+          currentUserId
+        )
+        if (!currentUserMember) {
+          throw new AppError(ErrorCode.Forbidden, 'Access denied to team')
+        }
+      }
     }
 
     return next()

--- a/apps/api/src/routes/user/teams/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/__tests__/handler.test.ts
@@ -8,8 +8,11 @@ import { getTeamHandler, updateTeamHandler } from '../handler'
 const mockTeam = {
   id: testUuids.TEAM_1,
   name: 'Engineering',
+  website: 'https://example.com',
+  description: 'Engineering team',
   createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-01')
+  updatedAt: new Date('2024-01-01'),
+  memberCount: 5
 }
 
 describe('getTeamHandler', () => {
@@ -17,39 +20,44 @@ describe('getTeamHandler', () => {
 
   let mockContext: any
   let mockJson: any
-  let mockGetTeam: any
+  let mockGet: any
 
   beforeEach(async () => {
     mockJson = mock((data: any, status: number) => ({ data, status }))
+    mockGet = mock((key: string) => {
+      if (key === 'team') {return mockTeam}
+
+      return undefined
+    })
     mockContext = {
       req: { valid: mock(() => ({ teamId: testUuids.TEAM_1 })) },
-      json: mockJson
+      json: mockJson,
+      get: mockGet
     }
-    mockGetTeam = mock(async () => ({ team: mockTeam }))
-
-    await moduleMocker.mock('@/use-cases/user', () => ({
-      getTeam: mockGetTeam
-    }))
   })
 
   afterEach(async () => {
     await moduleMocker.clear()
   })
 
-  it('should call getTeam and return team with OK status', async () => {
+  it('should get team from context and return with OK status', async () => {
     const result = await getTeamHandler(mockContext)
 
-    expect(mockGetTeam).toHaveBeenCalledWith(testUuids.TEAM_1)
+    expect(mockGet).toHaveBeenCalledWith('team')
     expect(mockJson).toHaveBeenCalledWith({ team: mockTeam }, HttpStatus.OK)
     expect(result.status).toBe(HttpStatus.OK)
   })
 
-  it('should propagate error when getTeam throws', async () => {
-    mockGetTeam.mockImplementation(async () => {
-      throw new Error('Team not found')
+  it('should handle undefined team from context', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'team') {return undefined}
+
+      return undefined
     })
 
-    expect(getTeamHandler(mockContext)).rejects.toThrow('Team not found')
+    await getTeamHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ team: undefined }, HttpStatus.OK)
   })
 })
 
@@ -98,9 +106,9 @@ describe('updateTeamHandler', () => {
 
   it('should propagate error when updateTeam throws', async () => {
     mockUpdateTeam.mockImplementation(async () => {
-      throw new Error('Team not found')
+      throw new Error('Database error')
     })
 
-    expect(updateTeamHandler(mockContext)).rejects.toThrow('Team not found')
+    expect(updateTeamHandler(mockContext)).rejects.toThrow('Database error')
   })
 })

--- a/apps/api/src/routes/user/teams/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/__tests__/handler.test.ts
@@ -25,7 +25,9 @@ describe('getTeamHandler', () => {
   beforeEach(async () => {
     mockJson = mock((data: any, status: number) => ({ data, status }))
     mockGet = mock((key: string) => {
-      if (key === 'team') {return mockTeam}
+      if (key === 'team') {
+        return mockTeam
+      }
 
       return undefined
     })
@@ -50,7 +52,9 @@ describe('getTeamHandler', () => {
 
   it('should handle undefined team from context', async () => {
     mockGet.mockImplementation((key: string) => {
-      if (key === 'team') {return undefined}
+      if (key === 'team') {
+        return undefined
+      }
 
       return undefined
     })

--- a/apps/api/src/routes/user/teams/$id/handler.ts
+++ b/apps/api/src/routes/user/teams/$id/handler.ts
@@ -1,14 +1,12 @@
 import { HttpStatus } from '@/net/http'
-import { getTeam, updateTeam } from '@/use-cases/user'
+import { updateTeam } from '@/use-cases/user'
 
 import type { TeamIdCtx, UpdateTeamCtx } from './schema'
 
 export const getTeamHandler = async (c: TeamIdCtx) => {
-  const { teamId } = c.req.valid('param')
+  const team = c.get('team')
 
-  const result = await getTeam(teamId)
-
-  return c.json(result, HttpStatus.OK)
+  return c.json({ team }, HttpStatus.OK)
 }
 
 export const updateTeamHandler = async (c: UpdateTeamCtx) => {

--- a/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
@@ -214,7 +214,11 @@ describe('cancelMemberInviteHandler', () => {
   beforeEach(async () => {
     mockJson = mock((data: any, status: number) => ({ data, status }))
     mockContext = {
-      req: { valid: mock(() => mockParams) },
+      get: mock(() => ({
+        id: testUuids.USER_1,
+        firstName: 'John',
+        email: 'john@example.com'
+      })),
       json: mockJson
     }
     mockCancelMemberInvite = mock(async () => ({ success: true }))
@@ -231,10 +235,11 @@ describe('cancelMemberInviteHandler', () => {
   it('should call cancelMemberInvite and return result with OK status', async () => {
     const result = await cancelMemberInviteHandler(mockContext)
 
-    expect(mockCancelMemberInvite).toHaveBeenCalledWith(
-      testUuids.TEAM_1,
-      testUuids.USER_1
-    )
+    expect(mockCancelMemberInvite).toHaveBeenCalledWith({
+      id: testUuids.USER_1,
+      firstName: 'John',
+      email: 'john@example.com'
+    })
     expect(mockJson).toHaveBeenCalledWith({ success: true }, HttpStatus.OK)
     expect(result.status).toBe(HttpStatus.OK)
   })

--- a/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
@@ -20,48 +20,23 @@ const mockMember = {
 const mockParams = { teamId: testUuids.TEAM_1, memberId: testUuids.USER_1 }
 
 describe('getTeamMemberHandler', () => {
-  const moduleMocker = new ModuleMocker(import.meta.url)
-
   let mockContext: any
   let mockJson: any
-  let mockGetTeamMember: any
 
-  beforeEach(async () => {
+  beforeEach(() => {
     mockJson = mock((data: any, status: number) => ({ data, status }))
     mockContext = {
-      req: { valid: mock(() => mockParams) },
+      get: mock(() => mockMember),
       json: mockJson
     }
-    mockGetTeamMember = mock(async () => ({ member: mockMember }))
-
-    await moduleMocker.mock('@/use-cases/user', () => ({
-      getTeamMember: mockGetTeamMember
-    }))
   })
 
-  afterEach(async () => {
-    await moduleMocker.clear()
-  })
-
-  it('should call getTeamMember and return member with OK status', async () => {
+  it('should return targetMember from context with OK status', async () => {
     const result = await getTeamMemberHandler(mockContext)
 
-    expect(mockGetTeamMember).toHaveBeenCalledWith(
-      testUuids.TEAM_1,
-      testUuids.USER_1
-    )
+    expect(mockContext.get).toHaveBeenCalledWith('targetMember')
     expect(mockJson).toHaveBeenCalledWith({ member: mockMember }, HttpStatus.OK)
     expect(result.status).toBe(HttpStatus.OK)
-  })
-
-  it('should propagate error when getTeamMember throws', async () => {
-    mockGetTeamMember.mockImplementation(async () => {
-      throw new Error('Member not found')
-    })
-
-    expect(getTeamMemberHandler(mockContext)).rejects.toThrow(
-      'Member not found'
-    )
   })
 })
 

--- a/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
@@ -151,8 +151,23 @@ describe('resendMemberInviteHandler', () => {
   beforeEach(async () => {
     mockJson = mock((data: any, status: number) => ({ data, status }))
     mockContext = {
-      req: { valid: mock(() => mockParams) },
-      get: mock(() => ({ id: testUuids.USER_2 })),
+      get: mock((key: string) => {
+        if (key === 'team') {
+          return { id: testUuids.TEAM_1, name: 'Test Team' }
+        }
+        if (key === 'targetMember') {
+          return {
+            id: testUuids.USER_1,
+            firstName: 'John',
+            email: 'john@example.com'
+          }
+        }
+        if (key === 'user') {
+          return { id: testUuids.USER_2 }
+        }
+
+        return undefined
+      }),
       json: mockJson
     }
     mockResendMemberInvite = mock(async () => ({ success: true }))
@@ -170,8 +185,8 @@ describe('resendMemberInviteHandler', () => {
     const result = await resendMemberInviteHandler(mockContext)
 
     expect(mockResendMemberInvite).toHaveBeenCalledWith(
-      testUuids.TEAM_1,
-      testUuids.USER_1,
+      { id: testUuids.TEAM_1, name: 'Test Team' },
+      { id: testUuids.USER_1, firstName: 'John', email: 'john@example.com' },
       testUuids.USER_2
     )
     expect(mockJson).toHaveBeenCalledWith({ success: true }, HttpStatus.OK)

--- a/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
@@ -42,9 +42,9 @@ export const removeTeamMemberHandler = async (c: MemberIdCtx) => {
 }
 
 export const cancelMemberInviteHandler = async (c: MemberIdCtx) => {
-  const { teamId, memberId } = c.req.valid('param')
+  const targetMember = c.get('targetMember')!
 
-  const result = await cancelMemberInvite(teamId, memberId)
+  const result = await cancelMemberInvite(targetMember)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
@@ -24,10 +24,11 @@ export const updateTeamMemberHandler = async (c: UpdateTeamMemberCtx) => {
 }
 
 export const resendMemberInviteHandler = async (c: MemberIdCtx) => {
-  const { teamId, memberId } = c.req.valid('param')
+  const team = c.get('team')!
+  const targetMember = c.get('targetMember')!
   const { id: inviterId } = c.get('user')
 
-  const result = await resendMemberInvite(teamId, memberId, inviterId)
+  const result = await resendMemberInvite(team, targetMember, inviterId)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
@@ -1,7 +1,6 @@
 import { HttpStatus } from '@/net/http'
 import {
   cancelMemberInvite,
-  getTeamMember,
   removeTeamMember,
   resendMemberInvite,
   updateTeamMember
@@ -10,11 +9,9 @@ import {
 import type { MemberIdCtx, UpdateTeamMemberCtx } from './schema'
 
 export const getTeamMemberHandler = async (c: MemberIdCtx) => {
-  const { teamId, memberId } = c.req.valid('param')
+  const targetMember = c.get('targetMember')!
 
-  const result = await getTeamMember(teamId, memberId)
-
-  return c.json(result, HttpStatus.OK)
+  return c.json({ member: targetMember }, HttpStatus.OK)
 }
 
 export const updateTeamMemberHandler = async (c: UpdateTeamMemberCtx) => {

--- a/apps/api/src/routes/user/teams/$id/members/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/__tests__/handler.test.ts
@@ -101,7 +101,12 @@ describe('createMemberHandler', () => {
           type === 'param' ? { teamId: testUuids.TEAM_1 } : body
         )
       },
-      get: mock(() => ({ id: testUuids.USER_1 })),
+      get: mock((key: string) => {
+        if (key === 'user') {return { id: testUuids.USER_1 }}
+        if (key === 'team') {return { id: testUuids.TEAM_1, name: 'Test Team' }}
+
+        return undefined
+      }),
       json: mockJson
     }
     mockInviteMember = mock(async () => ({
@@ -121,7 +126,7 @@ describe('createMemberHandler', () => {
     const result = await createMemberHandler(mockContext)
 
     expect(mockInviteMember).toHaveBeenCalledWith(
-      testUuids.TEAM_1,
+      { id: testUuids.TEAM_1, name: 'Test Team' },
       body,
       testUuids.USER_1
     )

--- a/apps/api/src/routes/user/teams/$id/members/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/__tests__/handler.test.ts
@@ -102,8 +102,12 @@ describe('createMemberHandler', () => {
         )
       },
       get: mock((key: string) => {
-        if (key === 'user') {return { id: testUuids.USER_1 }}
-        if (key === 'team') {return { id: testUuids.TEAM_1, name: 'Test Team' }}
+        if (key === 'user') {
+          return { id: testUuids.USER_1 }
+        }
+        if (key === 'team') {
+          return { id: testUuids.TEAM_1, name: 'Test Team' }
+        }
 
         return undefined
       }),

--- a/apps/api/src/routes/user/teams/$id/members/handler.ts
+++ b/apps/api/src/routes/user/teams/$id/members/handler.ts
@@ -21,11 +21,11 @@ export const getTeamMembersHandler = async (c: TeamIdCtx) => {
 }
 
 export const createMemberHandler = async (c: InviteMemberCtx) => {
-  const { teamId } = c.req.valid('param')
+  const team = c.get('team')!
   const member = c.req.valid('json')
   const { id: inviterId } = c.get('user')
 
-  const result = await inviteMember(teamId, member, inviterId)
+  const result = await inviteMember(team, member, inviterId)
 
   return c.json(result, HttpStatus.CREATED)
 }

--- a/apps/api/src/use-cases/user/__tests__/invites.test.ts
+++ b/apps/api/src/use-cases/user/__tests__/invites.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { TeamMember, TeamWithMemberCount, User } from '@/data'
+import type {
+  TeamMember,
+  TeamMemberDetails,
+  TeamWithMemberCount,
+  User
+} from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
@@ -203,12 +208,9 @@ describe('resendMemberInvite', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockTeam: TeamWithMemberCount
-  let mockMember: User
+  let mockTargetMember: TeamMemberDetails
   let mockInviter: User
-  let mockMembership: TeamMember
-  let mockTeamRepoFindById: any
   let mockUserRepoFindById: any
-  let mockTeamRepoFindMember: any
   let mockTokenRepoIssue: any
   let mockTransaction: any
   let mockEmailAgent: any
@@ -224,15 +226,18 @@ describe('resendMemberInvite', () => {
       memberCount: 5
     }
 
-    mockMember = {
+    mockTargetMember = {
       id: USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
       status: UserStatus.Pending,
-      role: Role.User,
       createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01')
+      updatedAt: new Date('2024-01-01'),
+      lastActive: null,
+      position: 'Developer',
+      inviter: null,
+      joinedAt: new Date('2024-01-01')
     }
 
     mockInviter = {
@@ -246,27 +251,7 @@ describe('resendMemberInvite', () => {
       updatedAt: new Date('2024-01-01')
     }
 
-    mockMembership = {
-      id: 1,
-      userId: USER_1,
-      teamId: TEAM_1,
-      position: 'Developer',
-      invitedBy: USER_2,
-      joinedAt: new Date('2024-01-01')
-    }
-
-    mockTeamRepoFindById = mock(async () => mockTeam)
-    mockUserRepoFindById = mock(async (id: string) => {
-      if (id === USER_1) {
-        return mockMember
-      }
-      if (id === USER_2) {
-        return mockInviter
-      }
-
-      return undefined
-    })
-    mockTeamRepoFindMember = mock(async () => mockMembership)
+    mockUserRepoFindById = mock(async () => mockInviter)
     mockTokenRepoIssue = mock(async () => {})
     mockTransaction = mock(
       async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
@@ -278,10 +263,6 @@ describe('resendMemberInvite', () => {
     }
 
     await moduleMocker.mock('@/data', () => ({
-      teamRepo: {
-        findById: mockTeamRepoFindById,
-        findMember: mockTeamRepoFindMember
-      },
       userRepo: { findById: mockUserRepoFindById },
       tokenRepo: { issue: mockTokenRepoIssue },
       db: { transaction: mockTransaction }
@@ -305,79 +286,36 @@ describe('resendMemberInvite', () => {
     await moduleMocker.clear()
   })
 
-  it('should throw NotFound when team does not exist', async () => {
-    mockTeamRepoFindById.mockImplementation(async () => undefined)
-
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toThrow(AppError)
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Team not found'
-    })
-  })
-
-  it('should throw NotFound when member does not exist', async () => {
-    mockUserRepoFindById.mockImplementation(async (id: string) => {
-      if (id === USER_2) {
-        return mockInviter
-      }
-
-      return undefined
-    })
-
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toThrow(AppError)
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Member not found'
-    })
-  })
-
-  it('should throw NotFound when member not in team', async () => {
-    mockTeamRepoFindMember.mockImplementation(async () => undefined)
-
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toThrow(AppError)
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Member not found in this team'
-    })
-  })
-
   it('should throw BadRequest when member already accepted invitation', async () => {
-    mockUserRepoFindById.mockImplementation(async (id: string) => {
-      if (id === USER_1) {
-        return { ...mockMember, status: UserStatus.Active }
-      }
-      if (id === USER_2) {
-        return mockInviter
-      }
+    mockTargetMember.status = UserStatus.Active
 
-      return undefined
-    })
-
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toThrow(AppError)
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toMatchObject({
+    expect(
+      resendMemberInvite(mockTeam, mockTargetMember, USER_2)
+    ).rejects.toThrow(AppError)
+    expect(
+      resendMemberInvite(mockTeam, mockTargetMember, USER_2)
+    ).rejects.toMatchObject({
       code: ErrorCode.BadRequest,
       message: 'Member has already accepted invitation'
     })
   })
 
   it('should throw NotFound when inviter does not exist', async () => {
-    mockUserRepoFindById.mockImplementation(async (id: string) => {
-      if (id === USER_1) {
-        return mockMember
-      }
+    mockUserRepoFindById.mockImplementation(async () => undefined)
 
-      return undefined
-    })
-
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toThrow(AppError)
-    expect(resendMemberInvite(TEAM_1, USER_1, USER_2)).rejects.toMatchObject({
+    expect(
+      resendMemberInvite(mockTeam, mockTargetMember, USER_2)
+    ).rejects.toThrow(AppError)
+    expect(
+      resendMemberInvite(mockTeam, mockTargetMember, USER_2)
+    ).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Inviter not found'
     })
   })
 
   it('should issue new token', async () => {
-    await resendMemberInvite(TEAM_1, USER_1, USER_2)
+    await resendMemberInvite(mockTeam, mockTargetMember, USER_2)
 
     expect(mockTokenRepoIssue).toHaveBeenCalledWith(
       USER_1,
@@ -392,7 +330,7 @@ describe('resendMemberInvite', () => {
   })
 
   it('should send invitation email with current inviter name', async () => {
-    await resendMemberInvite(TEAM_1, USER_1, USER_2)
+    await resendMemberInvite(mockTeam, mockTargetMember, USER_2)
 
     expect(mockEmailAgent.sendUserInvitationEmail).toHaveBeenCalledWith(
       'John',
@@ -405,7 +343,7 @@ describe('resendMemberInvite', () => {
   })
 
   it('should return success true', async () => {
-    const result = await resendMemberInvite(TEAM_1, USER_1, USER_2)
+    const result = await resendMemberInvite(mockTeam, mockTargetMember, USER_2)
 
     expect(result).toEqual({ success: true })
   })

--- a/apps/api/src/use-cases/user/__tests__/invites.test.ts
+++ b/apps/api/src/use-cases/user/__tests__/invites.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { Team, TeamMember, User } from '@/data'
+import type { TeamMember, TeamWithMemberCount, User } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
@@ -18,7 +18,7 @@ const { TEAM_1, USER_1, USER_2 } = testUuids
 describe('inviteMember', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
-  let mockTeam: Team
+  let mockTeam: TeamWithMemberCount
   let mockInviter: User
   let mockTeamRepoFindById: any
   let mockUserRepoFindByEmail: any
@@ -50,7 +50,8 @@ describe('inviteMember', () => {
       website: 'https://acme.com',
       description: 'A test team',
       createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01')
+      updatedAt: new Date('2024-01-01'),
+      memberCount: 5
     }
 
     mockInviter = {
@@ -127,30 +128,22 @@ describe('inviteMember', () => {
     await moduleMocker.clear()
   })
 
-  it('should throw NotFound when team does not exist', async () => {
-    mockTeamRepoFindById.mockImplementation(async () => undefined)
-
-    expect(inviteMember(TEAM_1, inviteParams, USER_2)).rejects.toThrow(AppError)
-    expect(inviteMember(TEAM_1, inviteParams, USER_2)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Team not found'
-    })
-  })
-
   it('should throw EmailAlreadyInUse when user email already exists', async () => {
     mockUserRepoFindByEmail.mockImplementation(async () => ({
       id: 'existing-user',
       email: 'john@example.com'
     }))
 
-    expect(inviteMember(TEAM_1, inviteParams, USER_2)).rejects.toThrow(AppError)
-    expect(inviteMember(TEAM_1, inviteParams, USER_2)).rejects.toMatchObject({
+    expect(inviteMember(mockTeam, inviteParams, USER_2)).rejects.toThrow(
+      AppError
+    )
+    expect(inviteMember(mockTeam, inviteParams, USER_2)).rejects.toMatchObject({
       code: ErrorCode.EmailAlreadyInUse
     })
   })
 
   it('should create user with pending status', async () => {
-    await inviteMember(TEAM_1, inviteParams, USER_2)
+    await inviteMember(mockTeam, inviteParams, USER_2)
 
     expect(mockUserRepoCreate).toHaveBeenCalledWith(
       {
@@ -164,7 +157,7 @@ describe('inviteMember', () => {
   })
 
   it('should add user to team with invitedBy', async () => {
-    await inviteMember(TEAM_1, inviteParams, USER_2)
+    await inviteMember(mockTeam, inviteParams, USER_2)
 
     expect(mockTeamRepoCreateMember).toHaveBeenCalledWith(
       {
@@ -178,7 +171,7 @@ describe('inviteMember', () => {
   })
 
   it('should send invitation email', async () => {
-    await inviteMember(TEAM_1, inviteParams, USER_2)
+    await inviteMember(mockTeam, inviteParams, USER_2)
 
     expect(mockEmailAgent.sendUserInvitationEmail).toHaveBeenCalledWith(
       'John',
@@ -191,7 +184,7 @@ describe('inviteMember', () => {
   })
 
   it('should return member data with team details', async () => {
-    const result = await inviteMember(TEAM_1, inviteParams, USER_2)
+    const result = await inviteMember(mockTeam, inviteParams, USER_2)
 
     expect(result.member).toEqual({
       id: USER_1,
@@ -209,7 +202,7 @@ describe('inviteMember', () => {
 describe('resendMemberInvite', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
-  let mockTeam: Team
+  let mockTeam: TeamWithMemberCount
   let mockMember: User
   let mockInviter: User
   let mockMembership: TeamMember
@@ -227,7 +220,8 @@ describe('resendMemberInvite', () => {
       website: 'https://acme.com',
       description: 'A test team',
       createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01')
+      updatedAt: new Date('2024-01-01'),
+      memberCount: 5
     }
 
     mockMember = {

--- a/apps/api/src/use-cases/user/__tests__/invites.test.ts
+++ b/apps/api/src/use-cases/user/__tests__/invites.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type {
-  TeamMember,
-  TeamMemberDetails,
-  TeamWithMemberCount,
-  User
-} from '@/data'
+import type { TeamMemberDetails, TeamWithMemberCount, User } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
@@ -352,41 +347,31 @@ describe('resendMemberInvite', () => {
 describe('cancelMemberInvite', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
-  let mockMember: User
-  let mockMembership: TeamMember
-  let mockUserRepoFindById: any
-  let mockTeamRepoFindMember: any
+  let mockTargetMember: TeamMemberDetails
   let mockTokenDeprecate: any
   let mockUserUpdate: any
   let mockTransaction: any
 
   beforeEach(async () => {
-    mockMember = {
+    mockTargetMember = {
       id: USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
       status: UserStatus.Pending,
-      role: Role.User,
       createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01')
-    }
-
-    mockMembership = {
-      id: 1,
-      userId: USER_1,
-      teamId: TEAM_1,
+      updatedAt: new Date('2024-01-01'),
+      lastActive: null,
       position: 'Developer',
-      invitedBy: USER_2,
+      inviter: null,
       joinedAt: new Date('2024-01-01')
     }
 
-    mockUserRepoFindById = mock(async () => mockMember)
-    mockTeamRepoFindMember = mock(async () => mockMembership)
     mockTokenDeprecate = mock(async () => {})
     mockUserUpdate = mock(async () => ({
-      ...mockMember,
-      status: UserStatus.Archived
+      ...mockTargetMember,
+      status: UserStatus.Archived,
+      updatedAt: new Date()
     }))
 
     mockTransaction = mock(
@@ -396,8 +381,7 @@ describe('cancelMemberInvite', () => {
     )
 
     await moduleMocker.mock('@/data', () => ({
-      userRepo: { findById: mockUserRepoFindById, update: mockUserUpdate },
-      teamRepo: { findMember: mockTeamRepoFindMember },
+      userRepo: { update: mockUserUpdate },
       tokenRepo: { deprecate: mockTokenDeprecate },
       db: { transaction: mockTransaction }
     }))
@@ -411,41 +395,18 @@ describe('cancelMemberInvite', () => {
     await moduleMocker.clear()
   })
 
-  it('should throw NotFound when member does not exist', async () => {
-    mockUserRepoFindById.mockImplementation(async () => undefined)
-
-    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toThrow(AppError)
-    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Member not found'
-    })
-  })
-
-  it('should throw NotFound when member is not in team', async () => {
-    mockTeamRepoFindMember.mockImplementation(async () => undefined)
-
-    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toThrow(AppError)
-    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Member not found'
-    })
-  })
-
   it('should throw BadRequest when member has already accepted invitation', async () => {
-    mockUserRepoFindById.mockImplementation(async () => ({
-      ...mockMember,
-      status: UserStatus.Active
-    }))
+    mockTargetMember.status = UserStatus.Active
 
-    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toThrow(AppError)
-    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toMatchObject({
+    expect(cancelMemberInvite(mockTargetMember)).rejects.toThrow(AppError)
+    expect(cancelMemberInvite(mockTargetMember)).rejects.toMatchObject({
       code: ErrorCode.BadRequest,
       message: 'Member has already accepted invitation'
     })
   })
 
   it('should deprecate token and archive user in a transaction', async () => {
-    const result = await cancelMemberInvite(TEAM_1, USER_1)
+    const result = await cancelMemberInvite(mockTargetMember)
 
     expect(mockTokenDeprecate).toHaveBeenCalledWith(
       USER_1,

--- a/apps/api/src/use-cases/user/__tests__/members.test.ts
+++ b/apps/api/src/use-cases/user/__tests__/members.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { TeamMember } from '@/data'
-
 import { ModuleMocker, testUuids } from '@/__tests__'
-import AppError from '@/errors/app-error'
-import ErrorCode from '@/errors/codes'
 import { UserStatus } from '@/types'
 
 import { removeTeamMember } from '../members'
@@ -14,23 +10,11 @@ const { TEAM_1, USER_1 } = testUuids
 describe('removeTeamMember', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
-  let mockMembership: TeamMember
-  let mockTeamRepoFindMember: any
   let mockTeamRepoDeleteMember: any
   let mockUserRepoUpdate: any
   let mockTransaction: any
 
   beforeEach(async () => {
-    mockMembership = {
-      id: 1,
-      userId: USER_1,
-      teamId: TEAM_1,
-      position: 'Developer',
-      invitedBy: null,
-      joinedAt: new Date('2024-01-01')
-    }
-
-    mockTeamRepoFindMember = mock(async () => mockMembership)
     mockTeamRepoDeleteMember = mock(async () => {})
     mockUserRepoUpdate = mock(async () => {})
     mockTransaction = mock(
@@ -41,7 +25,6 @@ describe('removeTeamMember', () => {
 
     await moduleMocker.mock('@/data', () => ({
       teamRepo: {
-        findMember: mockTeamRepoFindMember,
         deleteMember: mockTeamRepoDeleteMember
       },
       userRepo: { update: mockUserRepoUpdate },
@@ -53,16 +36,6 @@ describe('removeTeamMember', () => {
 
   afterEach(async () => {
     await moduleMocker.clear()
-  })
-
-  it('should throw NotFound when member is not in team', async () => {
-    mockTeamRepoFindMember.mockImplementation(async () => undefined)
-
-    expect(removeTeamMember(TEAM_1, USER_1)).rejects.toThrow(AppError)
-    expect(removeTeamMember(TEAM_1, USER_1)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Member not found'
-    })
   })
 
   it('should delete membership row in transaction', async () => {

--- a/apps/api/src/use-cases/user/__tests__/teams.test.ts
+++ b/apps/api/src/use-cases/user/__tests__/teams.test.ts
@@ -1,68 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { Team, TeamWithMemberCount } from '@/data'
+import type { Team } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
-import AppError from '@/errors/app-error'
-import ErrorCode from '@/errors/codes'
 
-import { getTeam, updateTeam } from '../teams'
+import { updateTeam } from '../teams'
 
 const { TEAM_1 } = testUuids
-
-describe('getTeam', () => {
-  const moduleMocker = new ModuleMocker(import.meta.url)
-
-  let mockTeam: TeamWithMemberCount
-  let mockTeamRepoFind: any
-  let mockTeamRepoFindMember: any
-
-  beforeEach(async () => {
-    mockTeam = {
-      id: TEAM_1,
-      name: 'Acme Corp',
-      website: 'https://acme.com',
-      description: 'A test team',
-      createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01'),
-      memberCount: 0
-    }
-
-    mockTeamRepoFind = mock(async () => mockTeam)
-    mockTeamRepoFindMember = mock(async () => ({
-      userId: testUuids.USER_1,
-      teamId: TEAM_1
-    }))
-
-    await moduleMocker.mock('@/data', () => ({
-      teamRepo: {
-        find: mockTeamRepoFind,
-        findMember: mockTeamRepoFindMember
-      }
-    }))
-  })
-
-  afterEach(async () => {
-    await moduleMocker.clear()
-  })
-
-  it('should return team when found', async () => {
-    const result = await getTeam(TEAM_1)
-
-    expect(mockTeamRepoFind).toHaveBeenCalledWith(TEAM_1)
-    expect(result).toEqual({ team: mockTeam })
-  })
-
-  it('should throw NotFound error when team does not exist', async () => {
-    mockTeamRepoFind.mockImplementation(async () => undefined)
-
-    expect(getTeam(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
-    expect(getTeam(testUuids.NON_EXISTENT)).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Team not found'
-    })
-  })
-})
 
 describe('updateTeam', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
@@ -114,22 +58,7 @@ describe('updateTeam', () => {
 
     const result = await updateTeam(TEAM_1, params)
 
-    expect(mockTeamRepoFindById).toHaveBeenCalledWith(TEAM_1)
     expect(mockTeamRepoUpdate).toHaveBeenCalledWith(TEAM_1, params)
     expect(result).toEqual({ team: mockUpdatedTeam })
-  })
-
-  it('should throw NotFound error when team does not exist', async () => {
-    mockTeamRepoFindById.mockImplementation(async () => undefined)
-
-    expect(
-      updateTeam(testUuids.NON_EXISTENT, { name: 'Test' })
-    ).rejects.toThrow(AppError)
-    expect(
-      updateTeam(testUuids.NON_EXISTENT, { name: 'Test' })
-    ).rejects.toMatchObject({
-      code: ErrorCode.NotFound,
-      message: 'Team not found'
-    })
   })
 })

--- a/apps/api/src/use-cases/user/index.ts
+++ b/apps/api/src/use-cases/user/index.ts
@@ -2,11 +2,6 @@ export { cancelMemberInvite, inviteMember, resendMemberInvite } from './invites'
 
 export { changePassword, getUser, updateUser } from './me'
 
-export {
-  getTeamMember,
-  getTeamMembers,
-  removeTeamMember,
-  updateTeamMember
-} from './members'
+export { getTeamMembers, removeTeamMember, updateTeamMember } from './members'
 
 export { updateTeam } from './teams'

--- a/apps/api/src/use-cases/user/index.ts
+++ b/apps/api/src/use-cases/user/index.ts
@@ -9,4 +9,4 @@ export {
   updateTeamMember
 } from './members'
 
-export { getTeam, updateTeam } from './teams'
+export { updateTeam } from './teams'

--- a/apps/api/src/use-cases/user/invites.ts
+++ b/apps/api/src/use-cases/user/invites.ts
@@ -151,16 +151,7 @@ export const resendMemberInvite = async (
   return { success: true }
 }
 
-export const cancelMemberInvite = async (teamId: string, memberId: string) => {
-  const [member, membership] = await Promise.all([
-    userRepo.findById(memberId),
-    teamRepo.findMember(teamId, memberId)
-  ])
-
-  if (!member || !membership) {
-    throw new AppError(ErrorCode.NotFound, 'Member not found')
-  }
-
+export const cancelMemberInvite = async (member: TeamMemberDetails) => {
   if (member.status !== UserStatus.Pending) {
     throw new AppError(
       ErrorCode.BadRequest,
@@ -169,8 +160,8 @@ export const cancelMemberInvite = async (teamId: string, memberId: string) => {
   }
 
   await db.transaction(async tx => {
-    await tokenRepo.deprecate(memberId, TokenType.UserInvite, tx)
-    await userRepo.update(memberId, { status: UserStatus.Archived }, tx)
+    await tokenRepo.deprecate(member.id, TokenType.UserInvite, tx)
+    await userRepo.update(member.id, { status: UserStatus.Archived }, tx)
   })
 
   return { success: true }

--- a/apps/api/src/use-cases/user/invites.ts
+++ b/apps/api/src/use-cases/user/invites.ts
@@ -1,3 +1,4 @@
+import type { TeamWithMemberCount } from '@/data'
 import type { PermissionsInput } from '@/types'
 
 import { authRepo, db, rbacRepo, teamRepo, tokenRepo, userRepo } from '@/data'
@@ -16,22 +17,17 @@ export interface InviteMemberInput {
 }
 
 export const inviteMember = async (
-  teamId: string,
+  team: TeamWithMemberCount,
   member: InviteMemberInput,
   inviterId: string
 ) => {
-  const [inviter, team, existingUser] = await Promise.all([
+  const [inviter, existingUser] = await Promise.all([
     userRepo.findById(inviterId),
-    teamRepo.findById(teamId),
     userRepo.findByEmail(member.email)
   ])
 
   if (!inviter) {
     throw new AppError(ErrorCode.NotFound, 'Inviter not found')
-  }
-
-  if (!team) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
   }
 
   if (existingUser) {
@@ -65,7 +61,7 @@ export const inviteMember = async (
     await teamRepo.createMember(
       {
         userId: newUser.id,
-        teamId,
+        teamId: team.id,
         position: member.position,
         invitedBy: inviterId
       },

--- a/apps/api/src/use-cases/user/invites.ts
+++ b/apps/api/src/use-cases/user/invites.ts
@@ -1,4 +1,4 @@
-import type { TeamWithMemberCount } from '@/data'
+import type { TeamMemberDetails, TeamWithMemberCount } from '@/data'
 import type { PermissionsInput } from '@/types'
 
 import { authRepo, db, rbacRepo, teamRepo, tokenRepo, userRepo } from '@/data'
@@ -111,31 +111,14 @@ export const inviteMember = async (
 }
 
 export const resendMemberInvite = async (
-  teamId: string,
-  memberId: string,
+  team: TeamWithMemberCount,
+  member: TeamMemberDetails,
   inviterId: string
 ) => {
-  const [inviter, team, member, membership] = await Promise.all([
-    userRepo.findById(inviterId),
-    teamRepo.findById(teamId),
-    userRepo.findById(memberId),
-    teamRepo.findMember(teamId, memberId)
-  ])
+  const inviter = await userRepo.findById(inviterId)
 
   if (!inviter) {
     throw new AppError(ErrorCode.NotFound, 'Inviter not found')
-  }
-
-  if (!team) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
-  }
-
-  if (!member) {
-    throw new AppError(ErrorCode.NotFound, 'Member not found')
-  }
-
-  if (!membership) {
-    throw new AppError(ErrorCode.NotFound, 'Member not found in this team')
   }
 
   if (member.status !== UserStatus.Pending) {
@@ -148,8 +131,8 @@ export const resendMemberInvite = async (
   const token = await db.transaction(async tx => {
     const { type, token, expiresAt } = generateToken(TokenType.UserInvite)
     await tokenRepo.issue(
-      memberId,
-      { userId: memberId, type, token, expiresAt },
+      member.id,
+      { userId: member.id, type, token, expiresAt },
       tx
     )
 

--- a/apps/api/src/use-cases/user/members.ts
+++ b/apps/api/src/use-cases/user/members.ts
@@ -23,12 +23,6 @@ export const updateTeamMember = async (
   memberId: string,
   input: UpdateTeamMemberInput
 ) => {
-  const existing = await teamRepo.findMember(teamId, memberId)
-
-  if (!existing) {
-    throw new AppError(ErrorCode.NotFound, 'Member not found')
-  }
-
   const updates: Array<Promise<unknown>> = []
 
   if (input.membership) {

--- a/apps/api/src/use-cases/user/members.ts
+++ b/apps/api/src/use-cases/user/members.ts
@@ -1,5 +1,4 @@
 import { db, teamRepo, userRepo } from '@/data'
-import { AppError, ErrorCode } from '@/errors'
 import { UserStatus } from '@/types'
 
 export const getTeamMembers = async (teamId: string) => {
@@ -41,12 +40,6 @@ export const updateTeamMember = async (
 }
 
 export const removeTeamMember = async (teamId: string, memberId: string) => {
-  const existing = await teamRepo.findMember(teamId, memberId)
-
-  if (!existing) {
-    throw new AppError(ErrorCode.NotFound, 'Member not found')
-  }
-
   await db.transaction(async tx => {
     await teamRepo.deleteMember(memberId, teamId, tx)
     await userRepo.update(memberId, { status: UserStatus.Archived }, tx)

--- a/apps/api/src/use-cases/user/members.ts
+++ b/apps/api/src/use-cases/user/members.ts
@@ -8,16 +8,6 @@ export const getTeamMembers = async (teamId: string) => {
   return { members }
 }
 
-export const getTeamMember = async (teamId: string, memberId: string) => {
-  const member = await teamRepo.findMember(teamId, memberId)
-
-  if (!member) {
-    throw new AppError(ErrorCode.NotFound, 'Member not found')
-  }
-
-  return { member }
-}
-
 export interface UpdateTeamMemberInput {
   membership?: {
     position?: string | null

--- a/apps/api/src/use-cases/user/teams.ts
+++ b/apps/api/src/use-cases/user/teams.ts
@@ -1,15 +1,4 @@
 import { teamRepo } from '@/data'
-import { AppError, ErrorCode } from '@/errors'
-
-export const getTeam = async (teamId: string) => {
-  const team = await teamRepo.find(teamId)
-
-  if (!team) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
-  }
-
-  return { team }
-}
 
 export interface UpdateTeamInput {
   name?: string
@@ -18,12 +7,6 @@ export interface UpdateTeamInput {
 }
 
 export const updateTeam = async (teamId: string, updates: UpdateTeamInput) => {
-  const existing = await teamRepo.findById(teamId)
-
-  if (!existing) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
-  }
-
   const team = await teamRepo.update(teamId, updates)
 
   return { team }


### PR DESCRIPTION
## Summary

- Refactor \`requireTeamAccess\` middleware: extract \`handleAdminAccess\` and \`handleUserAccess\` helpers to reduce cognitive complexity from 20 to below 15
- Remove redundant \`c.set('currentUser', undefined)\` and \`c.set('targetMember', undefined)\` calls — context variables are typed as \`| undefined\` and default to that without explicit assignment
- Eliminate 6+ redundant DB queries across team member operations by passing validated data through Hono context instead of re-fetching in handlers and use cases
- Remove dead validation code from use cases and handlers now fully covered by middleware
- Update tests to reflect context-based data access pattern

🤖 Generated with [Claude Code](https://claude.ai/code)