### PR TITLE
Add requirePermission to admin routes

### DIFF
--- a/apps/api/src/routes/admin/teams/index.ts
+++ b/apps/api/src/routes/admin/teams/index.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { validateBody, validateQuery } from '@/middleware'
+import { requirePermission, validateBody, validateQuery } from '@/middleware'
+import Permission from '@/types/permission'
 
 import { createTeamHandler, getTeamsHandler } from './handler'
 import { createTeamBodySchema, getTeamsQuerySchema } from './schema'
@@ -12,11 +13,13 @@ export const adminTeamsRoute = new Hono<AppContext>()
 adminTeamsRoute.get(
   '/teams',
   validateQuery(getTeamsQuerySchema),
+  requirePermission(Permission.ViewTeams),
   getTeamsHandler
 )
 
 adminTeamsRoute.post(
   '/teams',
   validateBody(createTeamBodySchema),
+  requirePermission(Permission.ManageTeams),
   createTeamHandler
 )

--- a/apps/api/src/routes/admin/users/$id/index.ts
+++ b/apps/api/src/routes/admin/users/$id/index.ts
@@ -2,18 +2,25 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { validateBody, validateParams } from '@/middleware'
+import { requirePermission, validateBody, validateParams } from '@/middleware'
+import Permission from '@/types/permission'
 
 import { getUserHandler, updateUserHandler } from './handler'
 import { updateUserBodySchema, userIdParamsSchema } from './schema'
 
 export const adminUserByIdRoute = new Hono<AppContext>()
 
-adminUserByIdRoute.get('/', validateParams(userIdParamsSchema), getUserHandler)
+adminUserByIdRoute.get(
+  '/',
+  validateParams(userIdParamsSchema),
+  requirePermission(Permission.ViewUsers),
+  getUserHandler
+)
 
 adminUserByIdRoute.patch(
   '/',
   validateParams(userIdParamsSchema),
   validateBody(updateUserBodySchema),
+  requirePermission(Permission.ManageUsers),
   updateUserHandler
 )

--- a/apps/api/src/routes/admin/users/__tests__/endpoint.test.ts
+++ b/apps/api/src/routes/admin/users/__tests__/endpoint.test.ts
@@ -66,7 +66,8 @@ describe('Admin Users Endpoint', () => {
       id: testUuids.ADMIN_1,
       email: 'admin@example.com',
       role: Role.Admin,
-      status: UserStatus.Active
+      status: UserStatus.Active,
+      permissions: ['view:users', 'manage:users']
     }
 
     const adminMiddleware: any = async (c: any, next: any) => {

--- a/apps/api/src/routes/admin/users/index.ts
+++ b/apps/api/src/routes/admin/users/index.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { validateQuery } from '@/middleware'
+import { requirePermission, validateQuery } from '@/middleware'
+import Permission from '@/types/permission'
 
 import { adminUserByIdRoute } from './$id'
 import { getUsersHandler } from './handler'
@@ -13,6 +14,7 @@ export const adminUsersRoute = new Hono<AppContext>()
 adminUsersRoute.get(
   '/users',
   validateQuery(getUsersQuerySchema),
+  requirePermission(Permission.ViewUsers),
   getUsersHandler
 )
 


### PR DESCRIPTION
## Summary

- Add `requirePermission` middleware to all admin route endpoints
- Guard `GET /admin/teams` with `ViewTeams`, `POST /admin/teams` with `ManageTeams`
- Guard `GET /admin/users` with `ViewUsers`
- Guard `GET /admin/users/:id` with `ViewUsers`, `PATCH /admin/users/:id` with `ManageUsers`
- Follow established order: `validate* → requirePermission → handler`
- Fix endpoint test mock user claims to include required permissions