### PR TITLE
Allow members to self-update personal data

### DIFF
--- a/apps/api/src/middleware/index.ts
+++ b/apps/api/src/middleware/index.ts
@@ -17,7 +17,10 @@ export {
   generalRateLimiter
 } from './rate-limiter'
 
-export { requirePermission } from './require-permission'
+export {
+  requirePermission,
+  requireSelfOrPermission
+} from './require-permission'
 
 export { secureHeaders } from './secure-headers'
 

--- a/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
+++ b/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
@@ -34,11 +34,7 @@ const makeApp = (permissions?: string[]) => {
   return app
 }
 
-const makeSelfOrPermissionApp = (
-  userId: string,
-  memberId: string,
-  permissions?: string[]
-) => {
+const makeSelfOrPermissionApp = (userId: string, permissions?: string[]) => {
   const app = new Hono<AppContext>()
   app.onError(onError)
   app.use('/teams/:teamId/members/:memberId', async (c, next) => {
@@ -97,21 +93,20 @@ describe('requireSelfOrPermission Middleware', () => {
 
   describe('Self access', () => {
     it('should allow when user id matches memberId', async () => {
-      const res = await makeSelfOrPermissionApp(
-        testUuids.USER_1,
-        testUuids.USER_1
-      ).request(path, { method: 'PATCH' })
+      const res = await makeSelfOrPermissionApp(testUuids.USER_1).request(
+        path,
+        { method: 'PATCH' }
+      )
 
       expect(res.status).toBe(HttpStatus.OK)
       expect((await res.json()).message).toBe('success')
     })
 
     it('should allow when user id matches memberId even without permissions', async () => {
-      const res = await makeSelfOrPermissionApp(
-        testUuids.USER_1,
-        testUuids.USER_1,
-        []
-      ).request(path, { method: 'PATCH' })
+      const res = await makeSelfOrPermissionApp(testUuids.USER_1, []).request(
+        path,
+        { method: 'PATCH' }
+      )
 
       expect(res.status).toBe(HttpStatus.OK)
     })
@@ -119,11 +114,9 @@ describe('requireSelfOrPermission Middleware', () => {
 
   describe('Permission access', () => {
     it('should allow when user has required permission and id differs', async () => {
-      const res = await makeSelfOrPermissionApp(
-        testUuids.USER_2,
-        testUuids.USER_1,
-        [Permission.ManageTeams]
-      ).request(path, { method: 'PATCH' })
+      const res = await makeSelfOrPermissionApp(testUuids.USER_2, [
+        Permission.ManageTeams
+      ]).request(path, { method: 'PATCH' })
 
       expect(res.status).toBe(HttpStatus.OK)
     })
@@ -131,21 +124,20 @@ describe('requireSelfOrPermission Middleware', () => {
 
   describe('Access denied', () => {
     it('should throw Forbidden when user is not self and lacks permission', async () => {
-      const res = await makeSelfOrPermissionApp(
-        testUuids.USER_2,
-        testUuids.USER_1,
-        []
-      ).request(path, { method: 'PATCH' })
+      const res = await makeSelfOrPermissionApp(testUuids.USER_2, []).request(
+        path,
+        { method: 'PATCH' }
+      )
 
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
       expect((await res.json()).code).toBe(ErrorCode.Forbidden)
     })
 
     it('should throw Forbidden when user is not self and permissions is undefined', async () => {
-      const res = await makeSelfOrPermissionApp(
-        testUuids.USER_2,
-        testUuids.USER_1
-      ).request(path, { method: 'PATCH' })
+      const res = await makeSelfOrPermissionApp(testUuids.USER_2).request(
+        path,
+        { method: 'PATCH' }
+      )
 
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
       expect((await res.json()).code).toBe(ErrorCode.Forbidden)

--- a/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
+++ b/apps/api/src/middleware/require-permission/__tests__/require-permission.test.ts
@@ -10,7 +10,10 @@ import HttpStatus from '@/net/http/status'
 import { Role, UserStatus } from '@/types'
 import Permission from '@/types/permission'
 
-import { requirePermission } from '../require-permission'
+import {
+  requirePermission,
+  requireSelfOrPermission
+} from '../require-permission'
 
 const makeApp = (permissions?: string[]) => {
   const app = new Hono<AppContext>()
@@ -27,6 +30,34 @@ const makeApp = (permissions?: string[]) => {
   })
   app.use('/', requirePermission(Permission.ViewAdmins))
   app.get('/', c => c.json({ message: 'success' }))
+
+  return app
+}
+
+const makeSelfOrPermissionApp = (
+  userId: string,
+  memberId: string,
+  permissions?: string[]
+) => {
+  const app = new Hono<AppContext>()
+  app.onError(onError)
+  app.use('/teams/:teamId/members/:memberId', async (c, next) => {
+    c.set('user', {
+      id: userId,
+      email: 'user@example.com',
+      role: Role.User,
+      status: UserStatus.Active,
+      permissions
+    })
+    await next()
+  })
+  app.use(
+    '/teams/:teamId/members/:memberId',
+    requireSelfOrPermission(Permission.ManageTeams)
+  )
+  app.patch('/teams/:teamId/members/:memberId', c =>
+    c.json({ message: 'success' })
+  )
 
   return app
 }
@@ -57,6 +88,67 @@ describe('requirePermission Middleware', () => {
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
       const json = await res.json()
       expect(json.code).toBe(ErrorCode.Forbidden)
+    })
+  })
+})
+
+describe('requireSelfOrPermission Middleware', () => {
+  const path = `/teams/${testUuids.TEAM_1}/members/${testUuids.USER_1}`
+
+  describe('Self access', () => {
+    it('should allow when user id matches memberId', async () => {
+      const res = await makeSelfOrPermissionApp(
+        testUuids.USER_1,
+        testUuids.USER_1
+      ).request(path, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.OK)
+      expect((await res.json()).message).toBe('success')
+    })
+
+    it('should allow when user id matches memberId even without permissions', async () => {
+      const res = await makeSelfOrPermissionApp(
+        testUuids.USER_1,
+        testUuids.USER_1,
+        []
+      ).request(path, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.OK)
+    })
+  })
+
+  describe('Permission access', () => {
+    it('should allow when user has required permission and id differs', async () => {
+      const res = await makeSelfOrPermissionApp(
+        testUuids.USER_2,
+        testUuids.USER_1,
+        [Permission.ManageTeams]
+      ).request(path, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.OK)
+    })
+  })
+
+  describe('Access denied', () => {
+    it('should throw Forbidden when user is not self and lacks permission', async () => {
+      const res = await makeSelfOrPermissionApp(
+        testUuids.USER_2,
+        testUuids.USER_1,
+        []
+      ).request(path, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      expect((await res.json()).code).toBe(ErrorCode.Forbidden)
+    })
+
+    it('should throw Forbidden when user is not self and permissions is undefined', async () => {
+      const res = await makeSelfOrPermissionApp(
+        testUuids.USER_2,
+        testUuids.USER_1
+      ).request(path, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      expect((await res.json()).code).toBe(ErrorCode.Forbidden)
     })
   })
 })

--- a/apps/api/src/middleware/require-permission/index.ts
+++ b/apps/api/src/middleware/require-permission/index.ts
@@ -1,1 +1,4 @@
-export { requirePermission } from './require-permission'
+export {
+  requirePermission,
+  requireSelfOrPermission
+} from './require-permission'

--- a/apps/api/src/middleware/require-permission/require-permission.ts
+++ b/apps/api/src/middleware/require-permission/require-permission.ts
@@ -15,3 +15,15 @@ export const requirePermission = (permission: Permission) =>
 
     return next()
   })
+
+export const requireSelfOrPermission = (permission: Permission) =>
+  createMiddleware<AppContext>(async (c, next) => {
+    const { id, permissions } = c.get('user')
+    const memberId = c.req.param('memberId')
+
+    if (id !== memberId && !permissions?.includes(permission)) {
+      throw new AppError(ErrorCode.Forbidden)
+    }
+
+    return next()
+  })

--- a/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
@@ -56,6 +56,10 @@ describe('updateTeamMemberHandler', () => {
       req: {
         valid: mock((type: string) => (type === 'param' ? mockParams : body))
       },
+      get: mock(() => ({
+        id: testUuids.USER_2,
+        permissions: ['manage:teams']
+      })),
       json: mockJson
     }
     mockUpdateTeamMember = mock(async () => ({ member: updatedMember }))

--- a/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
@@ -97,6 +97,36 @@ describe('updateTeamMemberHandler', () => {
       'Member not found'
     )
   })
+
+  it('should allow self-update of member fields', async () => {
+    const selfBody = { member: { firstName: 'Dentoni', lastName: 'Camacho' } }
+    mockContext.req.valid = mock((type: string) =>
+      type === 'param' ? mockParams : selfBody
+    )
+    mockContext.get = mock(() => ({ id: testUuids.USER_1, permissions: [] }))
+
+    const result = await updateTeamMemberHandler(mockContext)
+
+    expect(mockUpdateTeamMember).toHaveBeenCalledWith(
+      testUuids.TEAM_1,
+      testUuids.USER_1,
+      selfBody
+    )
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should forbid self-update when membership fields are included', async () => {
+    const selfBodyWithMembership = {
+      member: { firstName: 'Dentoni' },
+      membership: { position: 'Lead' }
+    }
+    mockContext.req.valid = mock((type: string) =>
+      type === 'param' ? mockParams : selfBodyWithMembership
+    )
+    mockContext.get = mock(() => ({ id: testUuids.USER_1, permissions: [] }))
+
+    expect(updateTeamMemberHandler(mockContext)).rejects.toThrow('Forbidden.')
+  })
 })
 
 describe('removeTeamMemberHandler', () => {

--- a/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/handler.ts
@@ -1,4 +1,6 @@
+import { AppError, ErrorCode } from '@/errors'
 import { HttpStatus } from '@/net/http'
+import { Permission } from '@/types'
 import {
   cancelMemberInvite,
   removeTeamMember,
@@ -17,6 +19,15 @@ export const getTeamMemberHandler = async (c: MemberIdCtx) => {
 export const updateTeamMemberHandler = async (c: UpdateTeamMemberCtx) => {
   const { teamId, memberId } = c.req.valid('param')
   const body = c.req.valid('json')
+  const { id: currentUserId, permissions } = c.get('user')
+
+  const isSelf = currentUserId === memberId
+  const canManage = permissions?.includes(Permission.ManageTeams) ?? false
+
+  // Prevent self-updating users from changing membership fields (e.g. position)
+  if (isSelf && !canManage && body.membership) {
+    throw new AppError(ErrorCode.Forbidden)
+  }
 
   const result = await updateTeamMember(teamId, memberId, body)
 

--- a/apps/api/src/routes/user/teams/$id/members/$id/index.ts
+++ b/apps/api/src/routes/user/teams/$id/members/$id/index.ts
@@ -4,6 +4,7 @@ import type { AppContext } from '@/context'
 
 import {
   requirePermission,
+  requireSelfOrPermission,
   requireTeamAccess,
   validateBody,
   validateParams
@@ -36,7 +37,7 @@ teamsMemberByIdRoute.patch(
   '/',
   validateParams(memberIdParamsSchema),
   validateBody(updateTeamMemberBodySchema),
-  requirePermission(Permission.ManageTeams),
+  requireSelfOrPermission(Permission.ManageTeams),
   requireTeamAccess,
   updateTeamMemberHandler
 )

--- a/apps/web/e2e/member-permissions.spec.js
+++ b/apps/web/e2e/member-permissions.spec.js
@@ -1,0 +1,295 @@
+import { faker } from '@faker-js/faker'
+import {
+  fillAcceptInviteFormAndSubmit,
+  fillMemberInviteFormAndSubmit,
+  logOut
+} from '@smela/e2e/actions'
+import { waitForApiCall, waitForApiCalls } from '@smela/e2e/api'
+import { generateEmailAddress } from '@smela/e2e/email'
+import { HttpStatus } from '@smela/ui/lib/net'
+import {
+  ACCEPT_INVITE_PATH,
+  CHECK_INVITE_PATH,
+  TEAM_MEMBER_PATH,
+  TEAM_MEMBERS_DEFAULT_PERMISSIONS_PATH,
+  TEAM_MEMBERS_PATH,
+  TEAMS_PATH
+} from '@smela/ui/services/backend/paths'
+
+import { expect, test } from './config/fixtures'
+
+const userCredentials = {
+  email: process.env.VITE_E2E_USER_EMAIL,
+  password: process.env.VITE_E2E_USER_PASSWORD
+}
+
+test.describe.serial('User: Member Permissions', () => {
+  let teamId
+  let readOnlyMemberId
+
+  const firstName = faker.person.firstName()
+  const lastName = faker.person.lastName()
+
+  const readOnlyMember = {
+    firstName,
+    lastName,
+    email: generateEmailAddress({ prefix: firstName }),
+    password: process.env.VITE_E2E_STRONG_PASSWORD,
+    position: faker.person.jobTitle()
+  }
+
+  test('invites a read-only member', async ({ page, t, login }) => {
+    await login(userCredentials)
+
+    const teamDetailPromise = waitForApiCall(page, {
+      path: TEAMS_PATH.replace(':teamId', ''),
+      method: 'GET',
+      status: HttpStatus.OK,
+      validateResponse: body => !!body?.team?.id
+    })
+
+    await page.goto('/team')
+    const { body: teamDetailBody } = await teamDetailPromise
+
+    teamId = teamDetailBody?.team?.id
+    expect(teamId).toBeTruthy()
+
+    const membersPromise = waitForApiCall(page, {
+      path: TEAM_MEMBERS_PATH.replace(':teamId', teamId),
+      method: 'GET',
+      status: HttpStatus.OK
+    })
+
+    await page.getByRole('tab', { name: t.team.tabs.members.label }).click()
+    await membersPromise
+
+    const defaultPermissionsPromise = waitForApiCall(page, {
+      path: TEAM_MEMBERS_DEFAULT_PERMISSIONS_PATH.replace(':teamId', teamId),
+      method: 'GET',
+      status: HttpStatus.OK
+    })
+
+    await page.getByRole('button', { name: t.invite.cta }).click()
+    await defaultPermissionsPromise
+
+    // Turn off all manage toggles
+    const manageLabel = t.permissions.actions.values.manage
+    const manageToggles = page.getByRole('switch', { name: manageLabel })
+
+    for (const toggle of await manageToggles.all()) {
+      if ((await toggle.getAttribute('aria-checked')) === 'true') {
+        await toggle.click()
+      }
+    }
+
+    const apiPromises = waitForApiCalls(page, [
+      {
+        path: TEAM_MEMBERS_PATH.replace(':teamId', teamId),
+        method: 'POST',
+        status: HttpStatus.CREATED
+      },
+      {
+        path: TEAMS_PATH.replace(':teamId', teamId),
+        method: 'GET',
+        status: HttpStatus.OK
+      },
+      {
+        path: TEAM_MEMBERS_PATH.replace(':teamId', teamId),
+        method: 'GET',
+        status: HttpStatus.OK
+      }
+    ])
+
+    await fillMemberInviteFormAndSubmit(page, readOnlyMember, t)
+    const [{ body: createdMember }] = await apiPromises
+
+    readOnlyMemberId = createdMember?.member?.id ?? createdMember?.id
+
+    await expect(page.getByText(t.invite.send.success)).toBeVisible()
+
+    const memberRow = page.getByRole('row', {
+      name: new RegExp(readOnlyMember.email)
+    })
+
+    await expect(memberRow).toBeVisible()
+    await expect(memberRow.getByText(t.status.values.pending)).toBeVisible()
+
+    await logOut(page, t)
+  })
+
+  test('read-only member accepts invite and has no manage permissions', async ({
+    page,
+    t,
+    emailService
+  }) => {
+    const { link } = await emailService.waitForInvitationEmail(
+      readOnlyMember.email
+    )
+
+    const checkInvitePromise = waitForApiCall(page, {
+      path: CHECK_INVITE_PATH,
+      method: 'GET',
+      status: HttpStatus.OK
+    })
+
+    await page.goto(link)
+    await checkInvitePromise
+
+    const acceptPromise = waitForApiCall(page, {
+      path: ACCEPT_INVITE_PATH,
+      method: 'POST',
+      status: HttpStatus.OK
+    })
+
+    await fillAcceptInviteFormAndSubmit(page, readOnlyMember.password, t)
+
+    await acceptPromise
+
+    // Navigate to own member detail to check permissions
+    await page.goto(`/team/members/${readOnlyMemberId}`)
+
+    // Permissions tab is hidden for non-managers — verify it is absent
+    await expect(
+      page.getByRole('tab', { name: t.permissions.name })
+    ).not.toBeVisible()
+
+    await logOut(page, t)
+  })
+
+  test('read-only member can edit own profile but not others', async ({
+    page,
+    t,
+    login
+  }) => {
+    await login({
+      email: readOnlyMember.email,
+      password: readOnlyMember.password
+    })
+
+    await page.goto('/team/members')
+
+    // Find own row by "You" badge and navigate to own profile
+    const ownRow = page.getByRole('row', { name: new RegExp(t.you) })
+
+    await ownRow.click()
+
+    await page.waitForURL(/\/team\/members\//)
+
+    // Edit first name — Save button appears only when form is dirty
+    const updatedName = faker.person.firstName()
+
+    const updatePromise = waitForApiCall(page, {
+      path: TEAM_MEMBER_PATH.replace(':teamId', teamId).replace(
+        ':memberId',
+        readOnlyMemberId
+      ),
+      method: 'PATCH',
+      status: HttpStatus.OK
+    })
+
+    await page.getByLabel(t.firstName.label).fill(updatedName)
+    await expect(page.getByRole('button', { name: t.save })).toBeVisible()
+    await page.getByRole('button', { name: t.save }).click()
+    await updatePromise
+
+    await expect(page.getByText(t.changesSaved)).toBeVisible()
+
+    // Navigate to alyce96's row — Save button must not be present
+    await page.goto('/team/members')
+
+    const otherRow = page.getByRole('row', {
+      name: new RegExp(userCredentials.email)
+    })
+
+    await otherRow.click()
+
+    await page.waitForURL(/\/team\/members\//)
+
+    await expect(page.getByRole('button', { name: t.save })).not.toBeVisible()
+
+    // First name input is read-only
+    await expect(page.getByLabel(t.firstName.label)).toHaveAttribute('readonly')
+
+    await logOut(page, t)
+  })
+
+  test('owner verifies member is Active and removes them from the team', async ({
+    page,
+    t,
+    login
+  }) => {
+    await login(userCredentials)
+
+    const membersPath = TEAM_MEMBERS_PATH.replace(':teamId', teamId)
+
+    const membersPromise = waitForApiCall(page, {
+      path: membersPath,
+      method: 'GET',
+      status: HttpStatus.OK,
+      validateResponse: body => Array.isArray(body?.members)
+    })
+
+    await page.goto('/team/members')
+    await membersPromise
+
+    const memberRow = page.getByRole('row', {
+      name: new RegExp(readOnlyMember.email)
+    })
+
+    await expect(memberRow).toBeVisible()
+    await expect(memberRow.getByText(t.status.values.active)).toBeVisible()
+
+    // Open member detail and verify no manage permissions on the Permissions tab
+    await memberRow.click()
+    await page.waitForURL(/\/team\/members\//)
+
+    await page.getByRole('tab', { name: t.permissions.name }).click()
+
+    const manageLabel = t.permissions.actions.values.manage
+    const manageToggles = page.getByRole('switch', { name: manageLabel })
+
+    for (const toggle of await manageToggles.all()) {
+      await expect(toggle).toHaveAttribute('aria-checked', 'false')
+    }
+
+    // Go back to members list and remove the member
+    await page.goto('/team/members')
+    await membersPromise
+
+    const initialTabText = await page
+      .getByRole('tab', { name: new RegExp(t.team.tabs.members.label) })
+      .textContent()
+
+    const initialCount = parseInt(initialTabText?.match(/\d+/)?.[0] ?? '0')
+
+    await memberRow.click({ button: 'right' })
+
+    const deletePath = TEAM_MEMBER_PATH.replace(':teamId', teamId).replace(
+      ':memberId',
+      readOnlyMemberId
+    )
+
+    const removePromises = waitForApiCalls(page, [
+      { path: deletePath, method: 'DELETE', status: HttpStatus.OK },
+      { path: membersPath, method: 'GET', status: HttpStatus.OK }
+    ])
+
+    await page.getByRole('menuitem', { name: t.contextMenu.remove }).click()
+    await page.getByRole('button', { name: t.team.members.remove.cta }).click()
+    await removePromises
+
+    await expect(page.getByText(t.team.members.remove.success)).toBeVisible()
+    await expect(memberRow).not.toBeVisible()
+
+    const expectedTabLabel = t.team.tabs.members.withCount.replace(
+      '{{count}}',
+      initialCount - 1
+    )
+
+    await expect(
+      page.getByRole('tab', { name: new RegExp(t.team.tabs.members.label) })
+    ).toHaveText(expectedTabLabel)
+
+    await logOut(page, t)
+  })
+})

--- a/apps/web/e2e/member-permissions.spec.js
+++ b/apps/web/e2e/member-permissions.spec.js
@@ -260,7 +260,9 @@ test.describe.serial('User: Member Permissions', () => {
       .getByRole('tab', { name: new RegExp(t.team.tabs.members.label) })
       .textContent()
 
-    const initialCount = parseInt(initialTabText?.match(/\d+/)?.[0] ?? '0')
+    const initialCount = Number.parseInt(
+      initialTabText?.match(/\d+/)?.[0] ?? '0'
+    )
 
     await memberRow.click({ button: 'right' })
 


### PR DESCRIPTION
## Summary

- Add `requireSelfOrPermission` middleware — passes if `memberId` matches the current user or user has the required permission
- Replace `requirePermission(ManageTeams)` with `requireSelfOrPermission(ManageTeams)` on `PATCH /teams/:teamId/members/:memberId`
- Block `membership` field updates (e.g. position) when self-updating without `ManageTeams` — prevents privilege escalation
- Export `requireSelfOrPermission` from middleware barrel exports
- Add unit tests for `requireSelfOrPermission`: self-match, self-match without permissions, manager access, non-self denied, non-self with undefined permissions
- Add handler tests: self-update of `member` fields succeeds; self-update with `membership` fields throws `Forbidden`
- Add E2E spec `member-permissions.spec.js`: invite read-only member, accept invite, verify no Permissions tab, verify self-edit works but other profiles are read-only, verify Active status and remove with count decrement