### PR TITLE
Bump app versions to 2026.06.02

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smela/admin",
   "private": true,
-  "version": "2026.04.20",
+  "version": "2026.06.02",
   "type": "module",
   "scripts": {
     "clean": "rm -rf node_modules",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smela/api",
-  "version": "2026.04.20",
+  "version": "2026.06.02",
   "scripts": {
     "clean": "rm -rf node_modules",
     "dev": "bun --watch src/app.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smela/web",
   "private": true,
-  "version": "2026.04.20",
+  "version": "2026.06.02",
   "type": "module",
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
## Summary

- Bump `@smela/api`, `@smela/web`, and `@smela/admin` versions from `2026.04.20` to `2026.06.02`