### PR TITLE
Add last-used auth badge, Google OAuth error tracking, and E2E guards

### DIFF
--- a/apps/admin/e2e/auth.spec.js
+++ b/apps/admin/e2e/auth.spec.js
@@ -7,10 +7,8 @@ test.describe('Auth', () => {
   }) => {
     await page.goto('/login')
 
-    await expect(page.getByText(t.doNotHaveAccount)).not.toBeVisible()
-    await expect(
-      page.getByRole('button', { name: t.continueWithGoogle })
-    ).not.toBeVisible()
+    await expect(page.getByText(t.doNotHaveAccount)).toHaveCount(0)
+    await expect(page.getByTestId('google-oauth-button')).toHaveCount(0)
   })
 
   test('/signup route renders 404 page', async ({ page, t }) => {

--- a/apps/admin/e2e/config/globalSetup.js
+++ b/apps/admin/e2e/config/globalSetup.js
@@ -1,3 +1,4 @@
+import { requireResendApiKey } from '@smela/e2e/env'
 import { loadEnv } from 'vite'
 
 // NODE_ENV=test is set in package.json scripts.
@@ -7,6 +8,7 @@ export const loadTestEnv = () => {
 }
 
 const globalSetup = () => {
+  requireResendApiKey()
   loadTestEnv()
 }
 

--- a/apps/api/src/routes/auth/google-oauth/handler.ts
+++ b/apps/api/src/routes/auth/google-oauth/handler.ts
@@ -13,11 +13,12 @@ import {
   setGoogleStateCookie,
   setRefreshCookie
 } from '@/net/http'
+import { getErrorTracker } from '@/services'
 import { buildAuthUrl, exchangeCodeForProfile } from '@/services/google'
 import { logInOrSignUpWithGoogle } from '@/use-cases/auth/google-oauth'
 
-const buildErrorRedirect = (reason: string) =>
-  `${env.FE_USER_URL}/login?reason=${encodeURIComponent(reason)}`
+const buildErrorRedirect = (code: string) =>
+  `${env.FE_USER_URL}/login?error=${encodeURIComponent(code)}`
 
 const buildCallbackRedirect = (isNew: boolean) => {
   const url = new URL(`${env.FE_USER_URL}/auth/google/callback`)
@@ -89,8 +90,13 @@ export const googleCallbackHandler = async (c: Context<AppContext>) => {
       HttpStatus.MOVED_TEMPORARILY
     )
   } catch (err) {
-    const reason = err instanceof AppError ? err.code : ErrorCode.InternalError
+    // Past this redirect the failure is silent to us — always capture
+    getErrorTracker().captureError(
+      err instanceof Error ? err : new Error(String(err))
+    )
 
-    return c.redirect(buildErrorRedirect(reason), HttpStatus.MOVED_TEMPORARILY)
+    const code = err instanceof AppError ? err.code : ErrorCode.InternalError
+
+    return c.redirect(buildErrorRedirect(code), HttpStatus.MOVED_TEMPORARILY)
   }
 }

--- a/apps/web/e2e/auth.spec.js
+++ b/apps/web/e2e/auth.spec.js
@@ -720,4 +720,19 @@ test.describe('Authentication: Google OAuth', () => {
     await expect(notice).toHaveText(t.backend['refresh-token/missing'])
     await expect(notice).not.toHaveClass(/text-destructive/)
   })
+
+  test('callback: shows destructive error when the backend redirects with a failure', async ({
+    page,
+    t
+  }) => {
+    const errorCode = 'auth/google-oauth-failed'
+
+    // The backend funnels token-exchange / user-info failures to this redirect
+    await page.goto(`/login?error=${encodeURIComponent(errorCode)}`)
+
+    const notice = page.getByRole('alert')
+
+    await expect(notice).toHaveText(t.backend[errorCode])
+    await expect(notice).toHaveClass(/text-destructive/)
+  })
 })

--- a/apps/web/e2e/config/globalSetup.js
+++ b/apps/web/e2e/config/globalSetup.js
@@ -1,3 +1,4 @@
+import { requireResendApiKey } from '@smela/e2e/env'
 import { loadEnv } from 'vite'
 
 // NODE_ENV=test is set in package.json scripts.
@@ -7,6 +8,7 @@ export const loadTestEnv = () => {
 }
 
 const globalSetup = () => {
+  requireResendApiKey()
   loadTestEnv()
 }
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -20,6 +20,7 @@
   },
   "exports": {
     "./config": "./src/config.js",
+    "./env": "./src/env.js",
     "./api": "./src/api.js",
     "./email": "./src/email/index.js",
     "./actions": "./src/actions/index.js"

--- a/packages/e2e/src/env.js
+++ b/packages/e2e/src/env.js
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { parseEnv } from 'node:util'
+
+// E2E relies on real emails flowing through Resend → the inbox API. The API
+// only sends via Resend when EMAIL_RESEND_API_KEY is set in its development env,
+// so we fail fast here instead of letting email-dependent tests time out.
+const API_ENV_PATH = fileURLToPath(
+  new URL('../../../apps/api/.env.development', import.meta.url)
+)
+
+export const requireResendApiKey = () => {
+  let env
+
+  try {
+    env = parseEnv(readFileSync(API_ENV_PATH, 'utf8'))
+  } catch {
+    throw new Error(
+      `E2E aborted: cannot read ${API_ENV_PATH}. Enable Resend by setting EMAIL_RESEND_API_KEY.`
+    )
+  }
+
+  if (!env.EMAIL_RESEND_API_KEY) {
+    throw new Error(
+      'E2E aborted: EMAIL_RESEND_API_KEY is missing or empty in apps/api/.env.development. Enable Resend.'
+    )
+  }
+}

--- a/packages/ui/src/components/socialAuth/SocialOAuthButton.jsx
+++ b/packages/ui/src/components/socialAuth/SocialOAuthButton.jsx
@@ -7,13 +7,16 @@ export const SocialOAuthButton = ({
   icon,
   label,
   onClick,
-  isPending
+  isPending,
+  ...props
 }) => (
   <Button
     variant='outline'
     className='relative w-full'
     onClick={onClick}
     disabled={isPending}
+    data-testid={`${provider}-oauth-button`}
+    {...props}
   >
     {icon}
     {label}


### PR DESCRIPTION
## Summary

Adds a "Last used" badge to auth methods, refactors social OAuth into reusable components, wires Google OAuth callback failures into Sentry, and hardens E2E setup.

## Changes

- **Last-used badge** — `LastUsedBadge` marks the auth method (email / Google) last used, backed by `lastAuthMethodStorage` recorded only on OAuth success.
- **Storage refactor** — extract `createKeyStorage` factory; `accessTokenStorage` and `lastAuthMethodStorage` build on it.
- **Social OAuth components** — extract `SocialOAuthButton` / `GoogleOAuthButton` / `SocialOAuthGroup`, "or continue with" separator, provider-name button, plus stories.
- **Sentry for OAuth** — Google callback handler captures all errors past the silent redirect; fixes redirect to use `?error=` so the login `Notice` alert renders.
- **E2E Resend guard** — `@smela/e2e/env` aborts web/admin E2E runs before any browser launches if `EMAIL_RESEND_API_KEY` is missing in `apps/api/.env.development` (uses Node 22 `util.parseEnv`).
- **E2E assertions** — assert the destructive error notice on a Google OAuth failure; assert OAuth-button absence by `data-testid` instead of brittle label text.
- **i18n** — reworded `lastUsed` (uk) and OAuth error strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)