### PR TITLE
Add SvgWrapper for DB-stored svg icons

### DIFF
--- a/.github/workflows/web-ci-ubuntu.yml
+++ b/.github/workflows/web-ci-ubuntu.yml
@@ -30,6 +30,7 @@ jobs:
     container: oven/bun:1.3.11
     environment: web-test
     env:
+      VITE_APP_NAME: ${{ vars.VITE_APP_NAME }}
       VITE_BE_BASE_URL: ${{ vars.VITE_BE_BASE_URL }}
       VITE_CAPTCHA_SITE_KEY: ${{ secrets.VITE_CAPTCHA_SITE_KEY }}
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/admin": {
       "name": "@smela/admin",
-      "version": "2026.4.20",
+      "version": "2026.6.2",
       "dependencies": {
         "@smela/i18n": "workspace:*",
         "@smela/ui": "workspace:*",
@@ -43,7 +43,7 @@
     },
     "apps/api": {
       "name": "@smela/api",
-      "version": "2026.4.20",
+      "version": "2026.6.2",
       "dependencies": {
         "@hono/zod-validator": "^0.7.6",
         "@react-email/components": "^1.0.8",
@@ -78,7 +78,7 @@
     },
     "apps/web": {
       "name": "@smela/web",
-      "version": "2026.4.20",
+      "version": "2026.6.2",
       "dependencies": {
         "@smela/i18n": "workspace:*",
         "@smela/ui": "workspace:*",
@@ -160,6 +160,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "dompurify": "^3.4.11",
         "http-status-codes": "^2.3.0",
         "i18next": "^26.0.4",
         "lucide-react": "^1.7.0",
@@ -968,6 +969,8 @@
 
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
@@ -1291,6 +1294,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -59,6 +59,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dompurify": "^3.4.11",
     "http-status-codes": "^2.3.0",
     "i18next": "^26.0.4",
     "lucide-react": "^1.7.0",

--- a/packages/ui/src/components/icons/GoogleIcon.jsx
+++ b/packages/ui/src/components/icons/GoogleIcon.jsx
@@ -1,27 +1,246 @@
-export const GoogleIcon = ({ width = 20, height = 20, className = '' }) => (
+import { cn } from '@ui/lib/utils'
+
+export const GoogleIcon = ({ className }) => (
   <svg
-    className={className}
-    width={width}
-    height={height}
-    viewBox='0 0 24 24'
+    className={cn('size-5', className)}
+    viewBox='0 0 268.1522 273.8827'
+    overflow='hidden'
     xmlns='http://www.w3.org/2000/svg'
+    xmlnsXlink='http://www.w3.org/1999/xlink'
   >
-    <path
-      d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'
-      fill='#4285F4'
-    />
-    <path
-      d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'
-      fill='#34A853'
-    />
-    <path
-      d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'
-      fill='#FBBC05'
-    />
-    <path
-      d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'
-      fill='#EA4335'
-    />
-    <path d='M1 1h22v22H1z' fill='none' />
+    <defs>
+      <linearGradient id='a'>
+        <stop offset='0' stopColor='#0fbc5c' />
+        <stop offset='1' stopColor='#0cba65' />
+      </linearGradient>
+      <linearGradient id='g'>
+        <stop offset='.2312727' stopColor='#0fbc5f' />
+        <stop offset='.3115468' stopColor='#0fbc5f' />
+        <stop offset='.3660131' stopColor='#0fbc5e' />
+        <stop offset='.4575163' stopColor='#0fbc5d' />
+        <stop offset='.540305' stopColor='#12bc58' />
+        <stop offset='.6993464' stopColor='#28bf3c' />
+        <stop offset='.7712418' stopColor='#38c02b' />
+        <stop offset='.8605665' stopColor='#52c218' />
+        <stop offset='.9150327' stopColor='#67c30f' />
+        <stop offset='1' stopColor='#86c504' />
+      </linearGradient>
+      <linearGradient id='h'>
+        <stop offset='.1416122' stopColor='#1abd4d' />
+        <stop offset='.2475151' stopColor='#6ec30d' />
+        <stop offset='.3115468' stopColor='#8ac502' />
+        <stop offset='.3660131' stopColor='#a2c600' />
+        <stop offset='.4456735' stopColor='#c8c903' />
+        <stop offset='.540305' stopColor='#ebcb03' />
+        <stop offset='.6156363' stopColor='#f7cd07' />
+        <stop offset='.6993454' stopColor='#fdcd04' />
+        <stop offset='.7712418' stopColor='#fdce05' />
+        <stop offset='.8605661' stopColor='#ffce0a' />
+      </linearGradient>
+      <linearGradient id='f'>
+        <stop offset='.3159041' stopColor='#ff4c3c' />
+        <stop offset='.6038179' stopColor='#ff692c' />
+        <stop offset='.7268366' stopColor='#ff7825' />
+        <stop offset='.884534' stopColor='#ff8d1b' />
+        <stop offset='1' stopColor='#ff9f13' />
+      </linearGradient>
+      <linearGradient id='b'>
+        <stop offset='.2312727' stopColor='#ff4541' />
+        <stop offset='.3115468' stopColor='#ff4540' />
+        <stop offset='.4575163' stopColor='#ff4640' />
+        <stop offset='.540305' stopColor='#ff473f' />
+        <stop offset='.6993464' stopColor='#ff5138' />
+        <stop offset='.7712418' stopColor='#ff5b33' />
+        <stop offset='.8605665' stopColor='#ff6c29' />
+        <stop offset='1' stopColor='#ff8c18' />
+      </linearGradient>
+      <linearGradient id='d'>
+        <stop offset='.4084578' stopColor='#fb4e5a' />
+        <stop offset='1' stopColor='#ff4540' />
+      </linearGradient>
+      <linearGradient id='c'>
+        <stop offset='.1315461' stopColor='#0cba65' />
+        <stop offset='.2097843' stopColor='#0bb86d' />
+        <stop offset='.2972969' stopColor='#09b479' />
+        <stop offset='.3962575' stopColor='#08ad93' />
+        <stop offset='.4771242' stopColor='#0aa6a9' />
+        <stop offset='.5684245' stopColor='#0d9cc6' />
+        <stop offset='.667385' stopColor='#1893dd' />
+        <stop offset='.7687273' stopColor='#258bf1' />
+        <stop offset='.8585063' stopColor='#3086ff' />
+      </linearGradient>
+      <linearGradient id='e'>
+        <stop offset='.3660131' stopColor='#ff4e3a' />
+        <stop offset='.4575163' stopColor='#ff8a1b' />
+        <stop offset='.540305' stopColor='#ffa312' />
+        <stop offset='.6156363' stopColor='#ffb60c' />
+        <stop offset='.7712418' stopColor='#ffcd0a' />
+        <stop offset='.8605665' stopColor='#fecf0a' />
+        <stop offset='.9150327' stopColor='#fecf08' />
+        <stop offset='1' stopColor='#fdcd01' />
+      </linearGradient>
+      <linearGradient
+        xlinkHref='#a'
+        id='s'
+        x1='219.6997'
+        y1='329.5351'
+        x2='254.4673'
+        y2='329.5351'
+        gradientUnits='userSpaceOnUse'
+      />
+      <radialGradient
+        xlinkHref='#b'
+        id='m'
+        gradientUnits='userSpaceOnUse'
+        gradientTransform='matrix(-1.936885,1.043001,1.455731,2.555422,290.5254,-400.6338)'
+        cx='109.6267'
+        cy='135.8619'
+        fx='109.6267'
+        fy='135.8619'
+        r='71.46001'
+      />
+      <radialGradient
+        xlinkHref='#c'
+        id='n'
+        gradientUnits='userSpaceOnUse'
+        gradientTransform='matrix(-3.512595,-4.45809,-1.692547,1.260616,870.8006,191.554)'
+        cx='45.25866'
+        cy='279.2738'
+        fx='45.25866'
+        fy='279.2738'
+        r='71.46001'
+      />
+      <radialGradient
+        xlinkHref='#d'
+        id='l'
+        cx='304.0166'
+        cy='118.0089'
+        fx='304.0166'
+        fy='118.0089'
+        r='47.85445'
+        gradientTransform='matrix(2.064353,-4.926832e-6,-2.901531e-6,2.592041,-297.6788,-151.7469)'
+        gradientUnits='userSpaceOnUse'
+      />
+      <radialGradient
+        xlinkHref='#e'
+        id='o'
+        gradientUnits='userSpaceOnUse'
+        gradientTransform='matrix(-0.2485783,2.083138,2.962486,0.3341668,-255.1463,-331.1636)'
+        cx='181.001'
+        cy='177.2013'
+        fx='181.001'
+        fy='177.2013'
+        r='71.46001'
+      />
+      <radialGradient
+        xlinkHref='#f'
+        id='p'
+        cx='207.6733'
+        cy='108.0972'
+        fx='207.6733'
+        fy='108.0972'
+        r='41.1025'
+        gradientTransform='matrix(-1.249206,1.343263,-3.896837,-3.425693,880.5011,194.9051)'
+        gradientUnits='userSpaceOnUse'
+      />
+      <radialGradient
+        xlinkHref='#g'
+        id='r'
+        gradientUnits='userSpaceOnUse'
+        gradientTransform='matrix(-1.936885,-1.043001,1.455731,-2.555422,290.5254,838.6834)'
+        cx='109.6267'
+        cy='135.8619'
+        fx='109.6267'
+        fy='135.8619'
+        r='71.46001'
+      />
+      <radialGradient
+        xlinkHref='#h'
+        id='j'
+        gradientUnits='userSpaceOnUse'
+        gradientTransform='matrix(-0.081402,-1.93722,2.926737,-0.1162508,-215.1345,632.8606)'
+        cx='154.8697'
+        cy='145.9691'
+        fx='154.8697'
+        fy='145.9691'
+        r='71.46001'
+      />
+      <filter
+        id='q'
+        x='-.04842873'
+        y='-.0582241'
+        width='1.096857'
+        height='1.116448'
+        colorInterpolationFilters='sRGB'
+      >
+        <feGaussianBlur stdDeviation='1.700914' />
+      </filter>
+      <filter
+        id='k'
+        x='-.01670084'
+        y='-.01009856'
+        width='1.033402'
+        height='1.020197'
+        colorInterpolationFilters='sRGB'
+      >
+        <feGaussianBlur stdDeviation='.2419367' />
+      </filter>
+      <clipPath clipPathUnits='userSpaceOnUse' id='i'>
+        <path
+          d='M371.3784 193.2406H237.0825v53.4375h77.167c-1.2405 7.5627-4.0259 15.0024-8.1049 21.7862-4.6734 7.7723-10.4511 13.6895-16.373 18.1957-17.7389 13.4983-38.42 16.2584-52.7828 16.2584-36.2824 0-67.2833-23.2865-79.2844-54.9287-.4843-1.1482-.8059-2.3344-1.1975-3.5068-2.652-8.0533-4.101-16.5825-4.101-25.4474 0-9.226 1.5691-18.0575 4.4301-26.3985 11.2851-32.8967 42.9849-57.4674 80.1789-57.4674 7.4811 0 14.6854.8843 21.5173 2.6481 15.6135 4.0309 26.6578 11.9698 33.4252 18.2494l40.834-39.7111c-24.839-22.616-57.2194-36.3201-95.8444-36.3201-30.8782-.00066-59.3863 9.55308-82.7477 25.6992-18.9454 13.0941-34.4833 30.6254-44.9695 50.9861-9.75366 18.8785-15.09441 39.7994-15.09441 62.2934 0 22.495 5.34891 43.6334 15.10261 62.3374v.126c10.3023 19.8567 25.3678 36.9537 43.6783 49.9878 15.9962 11.3866 44.6789 26.5516 84.0307 26.5516 22.6301 0 42.6867-4.0517 60.3748-11.6447 12.76-5.4775 24.0655-12.6217 34.3012-21.8036 13.5247-12.1323 24.1168-27.1388 31.3465-44.4041 7.2297-17.2654 11.097-36.7895 11.097-57.957 0-9.858-.9971-19.8694-2.6881-28.9684Z'
+          fill='#000'
+        />
+      </clipPath>
+    </defs>
+    <g transform='matrix(0.957922,0,0,0.985255,-90.17436,-78.85577)'>
+      <g clipPath='url(#i)'>
+        <path
+          d='M92.07563 219.9585c.14844 22.14 6.5014 44.983 16.11767 63.4234v.1269c6.9482 13.3919 16.4444 23.9704 27.2604 34.4518l65.326-23.67c-12.3593-6.2344-14.2452-10.0546-23.1048-17.0253-9.0537-9.0658-15.8015-19.4735-20.0038-31.677h-.1693l.1693-.1269c-2.7646-8.0587-3.0373-16.6129-3.1393-25.5029Z'
+          fill='url(#j)'
+          filter='url(#k)'
+        />
+        <path
+          d='M237.0835 79.02491c-6.4568 22.52569-3.988 44.42139 0 57.16129 7.4561.0055 14.6388.8881 21.4494 2.6464 15.6135 4.0309 26.6566 11.97 33.424 18.2496l41.8794-40.7256c-24.8094-22.58904-54.6663-37.2961-96.7528-37.33169Z'
+          fill='url(#l)'
+          filter='url(#k)'
+        />
+        <path
+          d='M236.9434 78.84678c-31.6709-.00068-60.9107 9.79833-84.8718 26.35902-8.8968 6.149-17.0612 13.2521-24.3311 21.1509-1.9045 17.7429 14.2569 39.5507 46.2615 39.3702 15.5284-17.9373 38.4946-29.5427 64.0561-29.5427.0233 0 .046.0019.0693.002l-1.0439-57.33536c-.0472-.00003-.0929-.00406-.1401-.00406Z'
+          fill='url(#m)'
+          filter='url(#k)'
+        />
+        <path
+          d='m341.4751 226.3788-28.2685 19.2848c-1.2405 7.5627-4.0278 15.0023-8.1068 21.7861-4.6734 7.7723-10.4506 13.6898-16.3725 18.196-17.7022 13.4704-38.3286 16.2439-52.6877 16.2553-14.8415 25.1018-17.4435 37.6749 1.0439 57.9342 22.8762-.0167 43.157-4.1174 61.0458-11.7965 12.9312-5.551 24.3879-12.7913 34.7609-22.0964 13.7061-12.295 24.4421-27.5034 31.7688-45.0003 7.3267-17.497 11.2446-37.2822 11.2446-58.7336Z'
+          fill='url(#n)'
+          filter='url(#k)'
+        />
+        <path
+          d='M234.9956 191.2104v57.4981h136.0062c1.1962-7.8745 5.1523-18.0644 5.1523-26.5001 0-9.858-.9963-21.899-2.6873-30.998Z'
+          fill='#3086ff'
+          filter='url(#k)'
+        />
+        <path
+          d='M128.3894 124.3268c-8.393 9.1191-15.5632 19.326-21.2483 30.3646-9.75351 18.8785-15.09402 41.8295-15.09402 64.3235 0 .317.02642.6271.02855.9436 4.31953 8.2244 59.66647 6.6495 62.45617 0-.0035-.3103-.0387-.6128-.0387-.9238 0-9.226 1.5696-16.0262 4.4306-24.3672 3.5294-10.2885 9.0557-19.7628 16.1223-27.9257 1.6019-2.0309 5.8748-6.3969 7.1214-9.0157.4749-.9975-.8621-1.5574-.9369-1.9085-.0836-.3927-1.8762-.0769-2.2778-.3694-1.2751-.9288-3.8001-1.4138-5.3334-1.8449-3.2772-.9215-8.7085-2.9536-11.7252-5.0601-9.5357-6.6586-24.417-14.6122-33.5047-24.2164Z'
+          fill='url(#o)'
+          filter='url(#k)'
+        />
+        <path
+          d='M162.0989 155.8569c22.1123 13.3013 28.4714-6.7139 43.173-12.9771L179.698 90.21568c-9.4075 3.92642-18.2957 8.80465-26.5426 14.50442-12.316 8.5122-23.192 18.8995-32.1763 30.7204Z'
+          fill='url(#p)'
+          filter='url(#q)'
+        />
+        <path
+          d='M171.0987 290.222c-29.6829 10.6413-34.3299 11.023-37.0622 29.2903 5.2213 5.0597 10.8312 9.74 16.7926 13.9835 15.9962 11.3867 46.766 26.5517 86.1178 26.5517.0462 0 .0904-.004.1366-.004v-59.1574c-.0298.0001-.064.002-.0938.002-14.7359 0-26.5113-3.8435-38.5848-10.5273-2.9768-1.6479-8.3775 2.7772-11.1229.799-3.7865-2.7284-12.8991 2.3508-16.1833-.9378Z'
+          fill='url(#r)'
+          filter='url(#k)'
+        />
+        <path
+          d='M219.6997 299.0227v59.9959c5.506.6402 11.2361 1.0289 17.2472 1.0289 6.0259 0 11.8556-.3073 17.5204-.8723v-59.7481c-6.3482 1.0777-12.3272 1.461-17.4776 1.461-5.9318 0-11.7005-.6858-17.29-1.8654Z'
+          opacity='.5'
+          fill='url(#s)'
+          filter='url(#k)'
+        />
+      </g>
+    </g>
   </svg>
 )

--- a/packages/ui/src/components/icons/SvgWrapper.jsx
+++ b/packages/ui/src/components/icons/SvgWrapper.jsx
@@ -5,12 +5,18 @@ import { useMemo } from 'react'
 const sanitize = svg =>
   DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })
 
-export const SvgWrapper = ({ svg, size = 24, className, ...props }) => {
+export const SvgWrapper = ({ svg, size = 24, label, className, ...props }) => {
   const __html = useMemo(() => sanitize(svg), [svg])
+
+  // Labeled icons expose a name to assistive tech; unlabeled ones are
+  // decorative and hidden so they aren't announced as empty images.
+  const a11y = label
+    ? { role: 'img', 'aria-label': label }
+    : { 'aria-hidden': true }
 
   return (
     <span
-      role='img'
+      {...a11y}
       className={cn('inline-flex shrink-0 [&>svg]:size-full', className)}
       style={{ width: size, height: size }}
       dangerouslySetInnerHTML={{ __html }}

--- a/packages/ui/src/components/icons/SvgWrapper.jsx
+++ b/packages/ui/src/components/icons/SvgWrapper.jsx
@@ -1,0 +1,20 @@
+import { cn } from '@ui/lib/utils'
+import DOMPurify from 'dompurify'
+import { useMemo } from 'react'
+
+const sanitize = svg =>
+  DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })
+
+export const SvgWrapper = ({ svg, size = 24, className, ...props }) => {
+  const __html = useMemo(() => sanitize(svg), [svg])
+
+  return (
+    <span
+      role='img'
+      className={cn('inline-flex shrink-0 [&>svg]:size-full', className)}
+      style={{ width: size, height: size }}
+      dangerouslySetInnerHTML={{ __html }}
+      {...props}
+    />
+  )
+}

--- a/packages/ui/src/components/icons/SvgWrapper.stories.jsx
+++ b/packages/ui/src/components/icons/SvgWrapper.stories.jsx
@@ -1,0 +1,59 @@
+import { SvgWrapper } from './SvgWrapper'
+
+// Sample svg strings, mirroring what an admin/designer pastes and we store in DB.
+const colorSvg = `<svg width="100%" height="100%" viewBox="-3 0 262 262" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid"><path d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622 38.755 30.023 2.685.268c24.659-22.774 38.875-56.282 38.875-96.027" fill="#4285F4"/><path d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055-34.523 0-63.824-22.773-74.269-54.25l-1.531.13-40.298 31.187-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1" fill="#34A853"/><path d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82 0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602l42.356-32.782" fill="#FBBC05"/><path d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0 79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251" fill="#EB4335"/></svg>`
+
+// Mono variant uses currentColor so it follows the surrounding text color / theme.
+const monoSvg = `<svg width="800px" height="800px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none"><path fill="currentColor" fill-rule="evenodd" d="M8 1C4.133 1 1 4.13 1 7.993c0 3.09 2.006 5.71 4.787 6.635.35.064.478-.152.478-.337 0-.166-.006-.606-.01-1.19-1.947.423-2.357-.937-2.357-.937-.319-.808-.778-1.023-.778-1.023-.635-.434.048-.425.048-.425.703.05 1.073.72 1.073.72.624 1.07 1.638.76 2.037.582.063-.452.244-.76.444-.935-1.554-.176-3.188-.776-3.188-3.456 0-.763.273-1.388.72-1.876-.072-.177-.312-.888.07-1.85 0 0 .586-.189 1.924.716A6.711 6.711 0 018 4.381c.595.003 1.194.08 1.753.236 1.336-.905 1.923-.717 1.923-.717.382.963.142 1.674.07 1.85.448.49.72 1.114.72 1.877 0 2.686-1.638 3.278-3.197 3.45.251.216.475.643.475 1.296 0 .934-.009 1.688-.009 1.918 0 .187.127.404.482.336A6.996 6.996 0 0015 7.993 6.997 6.997 0 008 1z" clip-rule="evenodd"/></svg>`
+
+export default {
+  title: 'Components/Icons/SvgWrapper',
+  component: SvgWrapper,
+  parameters: { layout: 'centered' },
+  decorators: [
+    Story => (
+      <div className='flex items-center justify-center'>
+        <Story />
+      </div>
+    )
+  ],
+  argTypes: {
+    svg: { control: 'text' }
+  },
+  args: {
+    svg: colorSvg
+  }
+}
+
+const sizes = [16, 24, 32, 48, 64, 96, 128]
+
+const SizeRow = ({ svg, className }) => (
+  <div className='flex flex-wrap items-center gap-6'>
+    {sizes.map(size => (
+      <div key={size} className='flex flex-col items-center gap-2'>
+        <SvgWrapper svg={svg} size={size} className={className} />
+        <span className='text-xs text-muted-foreground'>{size}px</span>
+      </div>
+    ))}
+  </div>
+)
+
+export const Playground = {
+  render: ({ svg }) => <SizeRow svg={svg} />
+}
+
+// Mono icon inherits `currentColor`; `text-foreground` makes it follow the
+// active theme — switch the Theme toolbar and every size flips automatically.
+export const Themed = {
+  render: () => <SizeRow svg={monoSvg} className='text-foreground' />
+}
+
+// Verifies sanitize() strips a malicious <script> from designer-pasted svg.
+export const SanitizesScript = {
+  render: () => (
+    <SvgWrapper
+      size={48}
+      svg={monoSvg.replace('</svg>', '<script>alert(1)</script></svg>')}
+    />
+  )
+}

--- a/packages/ui/src/components/icons/index.js
+++ b/packages/ui/src/components/icons/index.js
@@ -1,3 +1,4 @@
 export { ChevronIcon } from './ChevronIcon'
 export { GoogleIcon } from './GoogleIcon'
 export { Logo } from './Logo'
+export { SvgWrapper } from './SvgWrapper'


### PR DESCRIPTION
## Summary

Adds `SvgWrapper`, a component for rendering svg icons stored as strings in the database (e.g. designer/admin-managed social network icons), and refreshes the static `GoogleIcon`.

## Changes

- **`SvgWrapper`** — renders a DB-stored svg string, sanitized with DOMPurify (svg profile) before injection; sizes via a `size`-driven span with `[&>svg]:size-full` so any pasted svg (even with hardcoded `width`/`height`) scales correctly.
- **Accessibility** — `label` prop sets `role='img'` + `aria-label`; unlabeled icons are `aria-hidden` (decorative), satisfying jsx-a11y.
- Mono icons using `currentColor` follow the active theme via `className` (e.g. `text-foreground`).
- **Storybook** (`SvgWrapper.stories.jsx`) — `Playground` (paste any svg, see all sizes), `Themed` (GitHub mono icon flips with the Theme toolbar), `SanitizesScript` (proves `<script>` is stripped). Centered via a shared decorator.
- **`GoogleIcon`** — updated to the new official Google logo (gradients/filters), converted to JSX with camelCased attributes; switched to `className`-based sizing (`size-5` default) so it sizes correctly inside shadcn `Button`.
- Adds `dompurify` to `packages/ui`.
- **CI fix** — restore `VITE_APP_NAME` in the web CI workflow (still required by `env.js`; was dropped prematurely on `dev`, breaking unrelated tests).